### PR TITLE
Fix usage examples: replace script name by %prog

### DIFF
--- a/scripts/neighbor_joining.py
+++ b/scripts/neighbor_joining.py
@@ -21,9 +21,8 @@ script_info={}
 script_info['brief_description']="""Build a neighbor joining tree comparing samples"""
 script_info['script_description']="""The input to this step is a distance matrix (i.e. resulting file from beta_diversity.py)."""
 script_info['script_usage']=[]
-script_info['script_usage'].append(("""neighbor joining (nj) cluster (Single File):""","""To perform nj clustering on a single distance matrix (e.g.: beta_div.txt, a result file from beta_diversity.py) use the following idiom:""","""neighbor_joining.py -i beta_div.txt -o beta_div_cluster.tre"""))
-script_info['script_usage'].append(("""neighbor joining (Multiple Files):""","""The script also functions in batch mode if a folder is supplied as input. This script operates on every file in the input directory and creates a corresponding neighbor joining tree file in the output directory, e.g.:""","""neighbor_joining.py -i beta_div_weighted_unifrac/ -o beta_div_weighted_clusters/"""))
-script_info['script_usage'].append(('','',''))
+script_info['script_usage'].append(("""neighbor joining (nj) cluster (Single File):""","""To perform nj clustering on a single distance matrix (e.g.: beta_div.txt, a result file from beta_diversity.py) use the following idiom:""","""%prog -i beta_div.txt -o beta_div_cluster.tre"""))
+script_info['script_usage'].append(("""neighbor joining (Multiple Files):""","""The script also functions in batch mode if a folder is supplied as input. This script operates on every file in the input directory and creates a corresponding neighbor joining tree file in the output directory, e.g.:""","""%prog -i beta_div_weighted_unifrac/ -o beta_div_weighted_clusters/"""))
 script_info['output_description']="""The output is a newick formatted tree compatible with most standard tree viewing programs. Batch processing is also available, allowing the analysis of an entire directory of distance matrices."""
 script_info['required_options']=[
 make_option('-i', '--input_path',type='existing_path',


### PR DESCRIPTION
Deleted one empty usage example and replace neighbor_joining.py by %prog in usage examples
