### PR TITLE
Fixed issue with denoiser install.

### DIFF
--- a/qiime/denoiser/utils.py
+++ b/qiime/denoiser/utils.py
@@ -42,8 +42,8 @@ def get_denoiser_data_dir():
 def get_flowgram_ali_exe():
     """Return the path to the flowgram alignment prog
     """
-    fp = sys.prefix +\
-        "/qiime/support_files/denoiser/bin/FlowgramAli_4frame"
+    fp = get_qiime_project_dir() +\
+        "/qiime/support_files/denoiser/FlowgramAlignment/FlowgramAli_4frame"
     return fp
 
 def check_flowgram_ali_exe():

--- a/qiime/support_files/denoiser/FlowgramAlignment/Makefile
+++ b/qiime/support_files/denoiser/FlowgramAlignment/Makefile
@@ -6,8 +6,6 @@ FlowgramAli_4frame: FlowgramAli_4frame.lhs
 	ghc --make -O2 FlowgramAli_4frame
 # On ghc7+ consider using -with-rtsopts="-H100M" for increased speed
 
-install:
-	cp FlowgramAli_4frame ../bin/
 clean:
 	rm *.o
 	rm *.hi

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import re
 
 __author__ = "Greg Caporaso"
 __copyright__ = "Copyright 2011, The QIIME Project"
-__credits__ = ["Greg Caporaso", "Kyle Bittinger"]
+__credits__ = ["Greg Caporaso", "Kyle Bittinger", "Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.5.0-dev"
 __maintainer__ = "Greg Caporaso"
@@ -87,21 +87,22 @@ setup(name='QIIME',
       maintainer=__maintainer__,
       maintainer_email=__email__,
       url='http://www.qiime.org',
-      packages=['qiime','qiime/parallel','qiime/pycogent_backports','qiime/denoiser'],
+      packages=['qiime','qiime/parallel','qiime/pycogent_backports',
+                'qiime/denoiser'],
       scripts=glob('scripts/*py')+glob('scripts/ec2*'),
-      package_data={'qiime':\
-                   ['support_files/qiime_config',\
-                    'support_files/css/*css',\
-                    'support_files/html_templates/*html',\
-                    'support_files/images/*png',\
-                    'support_files/jar/*jar',\
-                    'support_files/js/*js',\
+      package_data={'qiime':
+                   ['support_files/qiime_config',
+                    'support_files/css/*css',
+                    'support_files/html_templates/*html',
+                    'support_files/images/*png',
+                    'support_files/jar/*jar',
+                    'support_files/js/*js',
                     'support_files/R/*r',
                     'support_files/denoiser/Data/*',
-                    'support_files/denoiser/TestData/*']},
-      data_files=[('qiime/support_files/denoiser/bin/',
-       ['qiime/support_files/denoiser/FlowgramAlignment/FlowgramAli_4frame'])],
-      long_description=long_description,
+                    'support_files/denoiser/TestData/*',
+                    'support_files/denoiser/FlowgramAlignment/'
+                        'FlowgramAli_4frame']},
+      long_description=long_description
 )
 
 if doc_imports_failed:


### PR DESCRIPTION
I think this originally broke because an empty qiime/support_files/denoiser/bin directory used to exist in the repo and it no longer does (not sure when it was removed or by whom). Thus, the 'make install' command started failing.

Using sys.prefix didn't work, so I changed it back to get_qiime_project_dir(). I also removed the install target of the denoiser makefile because it is unnecessary.

The solution (to support both dev and user installs) is much cleaner: the FlowgramAli_4frame is built in place when 'python setup.py build' is executed. qiime/denoiser/utils.py now looks for the executable there (relative to the QIIME project dir, of course) instead of looking for it in a bin/ directory somewhere else. This file will work in-place (if you're a dev and have your PYTHONPATH set to the QIIME repo itself), and with user installs via 'python setup.py install' as the file is now copied over into the build correctly.
