### PR TITLE
Fixed bug in MOTHUR taxonomy assignment for unassignable sequences.

### DIFF
--- a/qiime/pycogent_backports/mothur.py
+++ b/qiime/pycogent_backports/mothur.py
@@ -431,9 +431,19 @@ def parse_mothur_assignments(lines):
         if not line:
             continue
         seq_id, _, assignment = line.partition("\t")
+
+        # Special case: unidentified sequences should be given a
+        # confidence of 0.0.  Newer versions of MOTHUR return a real
+        # value for the confidence -- maybe we should consider keeping
+        # the value if present, because a sequence may conceivably be
+        # unknown with 85% confidence.
+        if re.match('unknown', assignment, re.IGNORECASE):
+            yield seq_id, ["Unknown"], 0.0
+            continue
+
         toks = assignment.rstrip(";").split(";")
         lineage = []
-        conf = None
+        conf = 0.0
         for tok in toks:
             matchobj = re.match("(.+)\((\d+)\)$", tok)
             if matchobj:

--- a/tests/test_assign_taxonomy.py
+++ b/tests/test_assign_taxonomy.py
@@ -588,6 +588,18 @@ class MothurTaxonAssignerTests(TestCase):
         e_lineage, e_conf = result['EF503697']
         self.assertTrue(len(e_lineage) < 3)
 
+    def test_unassignable(self):
+        f = open(self.seq_fp1, "w")
+        f.write(
+            ">MostlyTs\nTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
+            "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTATTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
+            "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n")
+        f.close()
+        
+        assigner = MothurTaxonAssigner(self.params)
+        result = assigner(self.seq_fp1)
+        self.assertEqual(result, {"MostlyTs": (["Unknown"], 0.0)})
+
 
 class RdpTaxonAssignerTests(TestCase):
     """Tests for the Rdp-based taxonomy assigner.


### PR DESCRIPTION
  This is now treated as a special case, and the confidence is set to 0.
