### PR TITLE
Alpha map

### DIFF
--- a/qiime/add_alpha_to_mapping_file.py
+++ b/qiime/add_alpha_to_mapping_file.py
@@ -13,7 +13,8 @@ __status__ = "Development"
 
 
 from copy import deepcopy
-from numpy import array, ndarray, floor, ceil, searchsorted
+from numpy import searchsorted
+from qiime.stats import quantile
 
 def add_alpha_diversity_values_to_mapping_file(metrics, alpha_sample_ids,
                                             alpha_data, mapping_file_headers,
@@ -71,7 +72,7 @@ def add_alpha_diversity_values_to_mapping_file(metrics, alpha_sample_ids,
         # when using the quantile method the levels change depending on the
         # metric being used; hence the calculation and normalization of the data
         if method == 'quantile':
-            levels = quantile([norm(element[0], metric_min, metric_max)\
+            levels = quantile([norm(element[0], metric_min, metric_max)
                 for element in data], overall_probs)
 
         # get the normalized value of diversity and the tag for each value
@@ -90,7 +91,7 @@ def add_alpha_diversity_values_to_mapping_file(metrics, alpha_sample_ids,
                 # data fields should be strings
                 row.extend(map(str, data[data_index]))
             except ValueError:
-                row.extend([missing_value_name, missing_value_name,\
+                row.extend([missing_value_name, missing_value_name,
                     missing_value_name])
 
     return new_mapping_file_data, new_mapping_file_headers
@@ -124,60 +125,5 @@ def _get_level(value, levels, prefix=None):
         output = '{0}_{1}_of_{2}'.format(prefix, value_level, len(levels)+1)
     else:
         output = value_level
-
-    return output
-
-def quantile(data, quantiles):
-    """calculates quantiles of a dataset matching a given list of probabilities
-
-    Input:
-    data: 1-D list or numpy array with data to calculate the quantiles
-    quantiles: list of probabilities, floating point values between 0 and 1
-
-    Output:
-    A list of elements drawn from 'data' that corresponding to the list of
-    probabilities. This by default is using R. type 7 method for computation of
-    the quantiles.
-    """
-
-    assert type(data) == list or type(data) == ndarray, "Data must be either"+\
-        " a Python list or a NumPy 1-D array"
-    assert type(quantiles) == list or type(quantiles) == ndarray, "Quantiles"+\
-        " must be either a Python list or a NumPy 1-D array"
-    assert all(map(lambda x: x>=0 and x<=1, quantiles)), "All the elements "+\
-        "in the quantiles list must be greater than 0 and lower than one"
-
-    # unless the user wanted, do not modify the data
-    data = deepcopy(data)
-
-    if type(data) != ndarray:
-        data = array(data)
-    data.sort()
-
-    output = []
-    # if needed different quantile methods could be used
-    for one_quantile in quantiles:
-        output.append(_quantile(data, one_quantile))
-
-    return output
-
-def _quantile(data, quantile):
-    """gets a single quantile value for a dataset using R. type 7 method
-
-    Input:
-    data: sorted 1-d numpy array with float or int elements
-    quantile: floating point value between 0 and 1
-
-    Output:
-    quantile value of data
-
-    This function is based on cogent.maths.stats.util.NumbersI
-    """
-    index = quantile*(len(data)-1)
-    bottom_index = int(floor(index))
-    top_index = int(ceil(index))
-
-    difference = index-bottom_index
-    output = (1-difference)*data[bottom_index]+difference*data[top_index]
 
     return output

--- a/scripts/add_alpha_to_mapping_file.py
+++ b/scripts/add_alpha_to_mapping_file.py
@@ -25,47 +25,47 @@ script_info['script_description'] = "Add alpha diversity data to a mapping "+\
     "alpha diversity data; the first column being the raw value, the second "+\
     "being a normalized raw value and the third one a label classifying "+\
     "the bin where this value fits based on the normalized value."
-script_info['script_usage'] = [("Adding alpha diversity data:","Add the alpha"+\
-    " diversity values to a mapping file and classify the normalized values "+\
-    "into 4 bins, where the limits will be  0 < x <= 0.25 for the first bin "+\
-    "0.25 < x <= 0.5 for the second bin, 0.5 < x <= 0.75 for the third bin "+\
-    "and 0.75 < x <= 1 for the fourth bin.","%prog -i adiv_pd.txt -m mapping"+\
+script_info['script_usage'] = [("Adding alpha diversity data:","Add the alpha"
+    " diversity values to a mapping file and classify the normalized values "
+    "into 4 bins, where the limits will be  0 < x <= 0.25 for the first bin "
+    "0.25 < x <= 0.5 for the second bin, 0.5 < x <= 0.75 for the third bin "
+    "and 0.75 < x <= 1 for the fourth bin.","%prog -i adiv_pd.txt -m mapping"
     ".txt -b 4 -o alpha_mapping.txt")]
-script_info['script_usage'].append(("Adding alpha diversity data with the "+\
-    "quantile method:", "Add the alpha diversity values to a mapping file and"+\
-    " classify the normalized values using the quartiles of the distribution "+\
-    "of this values.", "%prog -i adiv_pd.txt -m mapping.txt -b 4 -o alpha_"+\
+script_info['script_usage'].append(("Adding alpha diversity data with the "
+    "quantile method:", "Add the alpha diversity values to a mapping file and"
+    " classify the normalized values using the quartiles of the distribution "
+    "of this values.", "%prog -i adiv_pd.txt -m mapping.txt -b 4 -o alpha_"
     "mapping_quantile.txt --binning_method=quantile"))
 script_info['output_description']= "The result of running this script is a "+\
     "metadata mapping file that will include 3 new columns per alpha "+\
     "diversity metric included in the alpha diversity file. For example, with"+\
     " an alpha diversity file with only PD_whole_tree, the new columns will "+\
     "PD_whole_tree_alpha, PD_whole_tree_normalized and PD_whole_tree_bin."
-script_info['required_options'] = [\
-make_option('-i','--alpha_fp',type="existing_filepath",\
-    help='alpha diversity data with one or multiple metrics i. e. the output'+\
-    ' of alpha_diversity.py'),\
-make_option('-m','--mapping_fp',type="existing_filepath",\
-    help='mapping file to modify by adding the alpha diversity data'),\
+script_info['required_options'] = [
+make_option('-i','--alpha_fp',type="existing_filepath",
+    help='alpha diversity data with one or multiple metrics i. e. the output'
+    ' of alpha_diversity.py'),
+make_option('-m','--mapping_fp',type="existing_filepath",
+    help='mapping file to modify by adding the alpha diversity data'),
 ]
-script_info['optional_options'] = [\
-make_option('-o','--output_mapping_fp',type="new_filepath",\
-    help='filepath for the modified mapping file [default: %default]',\
-    default='mapping_file_with_alpha.txt'),\
-make_option('-b','--number_of_bins',type="int",\
-    help='number of bins [default: %default]', default=4),\
-make_option('-x','--missing_value_name',type="string",\
-    help='bin prefix name for the sample identifiers that exist in the '+\
-        'mapping file (mapping_fp) but not in the alpha diversity file '+\
+script_info['optional_options'] = [
+make_option('-o','--output_mapping_fp',type="new_filepath",
+    help='filepath for the modified mapping file [default: %default]',
+    default='mapping_file_with_alpha.txt'),
+make_option('-b','--number_of_bins',type="int",
+    help='number of bins [default: %default]', default=4),
+make_option('-x','--missing_value_name',type="string",
+    help='bin prefix name for the sample identifiers that exist in the '
+        'mapping file (mapping_fp) but not in the alpha diversity file '
         '(alpha_fp) [default: %default]', default='N/A'),
 make_option('--binning_method', type='string', default='equal',
-    help='Select the method name to create the bins, the options are '+\
-        '\'equal\' and \'quantile\'. Both methods work over the normalized '+\
-        'alpha diversity values. On the one hand \'equal\' will assign the '+\
-        'bins on equally spaced limits, depending on the value of --number'+\
-        '_of_bins i. e. if you select 4 the limits will be [0.25, 0.50, 0.75]'+\
-        '. On the other hand \'quantile\' will select the limits based on the'+\
-        ' --number_of_bins i. e. the limits will be the quartiles if 4 is '+\
+    help='Select the method name to create the bins, the options are '
+        '\'equal\' and \'quantile\'. Both methods work over the normalized '
+        'alpha diversity values. On the one hand \'equal\' will assign the '
+        'bins on equally spaced limits, depending on the value of --number'
+        '_of_bins i. e. if you select 4 the limits will be [0.25, 0.50, 0.75]'
+        '. On the other hand \'quantile\' will select the limits based on the'
+        ' --number_of_bins i. e. the limits will be the quartiles if 4 is '
         'selected [default: %default].')
 ]
 script_info['version'] = __version__
@@ -89,14 +89,14 @@ def main():
             % opts.number_of_bins
 
     # parse the data from the files
-    mapping_file_data, mapping_file_headers, comments = parse_mapping_file(\
+    mapping_file_data, mapping_file_headers, comments = parse_mapping_file(
         open(mapping_fp, 'U'))
     metrics, alpha_sample_ids, alpha_data = parse_matrix(open(alpha_fp, 'U'))
 
     # add the alpha diversity data to the mapping file
     out_mapping_file_data, out_mapping_file_headers = \
-        add_alpha_diversity_values_to_mapping_file(metrics, alpha_sample_ids,\
-        alpha_data, mapping_file_headers, mapping_file_data, number_of_bins,\
+        add_alpha_diversity_values_to_mapping_file(metrics, alpha_sample_ids,
+        alpha_data, mapping_file_headers, mapping_file_data, number_of_bins,
         binning_method, missing_value_name)
 
     # format the new data and write it down

--- a/tests/test_add_alpha_to_mapping_file.py
+++ b/tests/test_add_alpha_to_mapping_file.py
@@ -12,23 +12,22 @@ __email__ = "yoshiki89@gmail.com"
 __status__ = "Development"
 
 from numpy import array, median
-from numpy.random import shuffle
 from cogent.util.unit_test import TestCase, main
-from qiime.add_alpha_to_mapping_file import (add_alpha_diversity_values_to_mapping_file,\
-                                            _get_level, quantile, _quantile)
+from qiime.add_alpha_to_mapping_file import (add_alpha_diversity_values_to_mapping_file,
+                                            _get_level)
 
 class TopLevelTests(TestCase):
     
     def setUp(self):
         self.metrics = ['chao1', 'PD_whole_tree']
-        self.alpha_diversity_data =  array([[ 173., 6.39901], [332.5, 7.48089],\
-            [189.9375, 5.5103],[223.58333333, 6.26648], [176.8, 5.40341],\
+        self.alpha_diversity_data =  array([[ 173., 6.39901], [332.5, 7.48089],
+            [189.9375, 5.5103],[223.58333333, 6.26648], [176.8, 5.40341],
             [90., 4.84129], [127., 4.50866], [211., 7.3172], [146., 6.57543]])
-        self.sample_ids = ['PC.636', 'PC.635', 'PC.356', 'PC.481', 'PC.354',\
+        self.sample_ids = ['PC.636', 'PC.635', 'PC.356', 'PC.481', 'PC.354',
             'PC.593', 'PC.355', 'PC.607', 'PC.634']
 
         self.mapping_file_data = MAPPING_FILE_DATA
-        self.mapping_file_headers = ['SampleID', 'BarcodeSequence',\
+        self.mapping_file_headers = ['SampleID', 'BarcodeSequence',
             'LinkerPrimerSequence', 'Treatment', 'DOB', 'Description']
 
     def test_add_alpha_diversity_values_to_mapping_file(self):
@@ -36,15 +35,15 @@ class TopLevelTests(TestCase):
 
         # regular case no special cases for avg method
         expected_mapping_file_data = MAPPING_FILE_DATA_WITH_ALPHA_A
-        expected_mapping_file_headers = ['SampleID', 'BarcodeSequence',\
-            'LinkerPrimerSequence', 'Treatment', 'DOB', 'Description',\
-            'chao1_alpha', 'chao1_normalized_alpha', 'chao1_alpha_label',\
-            'PD_whole_tree_alpha', 'PD_whole_tree_normalized_alpha',\
+        expected_mapping_file_headers = ['SampleID', 'BarcodeSequence',
+            'LinkerPrimerSequence', 'Treatment', 'DOB', 'Description',
+            'chao1_alpha', 'chao1_normalized_alpha', 'chao1_alpha_label',
+            'PD_whole_tree_alpha', 'PD_whole_tree_normalized_alpha',
             'PD_whole_tree_alpha_label']
 
         out_mapping_file_data, out_mapping_file_headers =\
-            add_alpha_diversity_values_to_mapping_file(self.metrics,\
-                self.sample_ids, self.alpha_diversity_data,\
+            add_alpha_diversity_values_to_mapping_file(self.metrics,
+                self.sample_ids, self.alpha_diversity_data,
                 self.mapping_file_headers, self.mapping_file_data, 4, 'equal')
 
         self.assertEquals(out_mapping_file_data, expected_mapping_file_data)
@@ -53,8 +52,8 @@ class TopLevelTests(TestCase):
         # regular case no special cases for quantile method
         expected_mapping_file_data = MAPPING_FILE_DATA_WITH_ALPHA_B
         out_mapping_file_data, out_mapping_file_headers =\
-            add_alpha_diversity_values_to_mapping_file(self.metrics,\
-                self.sample_ids, self.alpha_diversity_data,\
+            add_alpha_diversity_values_to_mapping_file(self.metrics,
+                self.sample_ids, self.alpha_diversity_data,
                 self.mapping_file_headers, self.mapping_file_data, 4, 'quantile')
 
         self.assertEquals(out_mapping_file_data, expected_mapping_file_data)
@@ -101,71 +100,26 @@ class TopLevelTests(TestCase):
         with self.assertRaises(AssertionError):
             output = _get_level(-1, [0.25, 0.5, 0.75])
 
+MAPPING_FILE_DATA = [
+    ['PC.354','AGCACGAGCCTA','YATGCTGCCTCCCGTAGGAGT','Control','20061218','Control_mouse_I.D._354'],
+    ['PC.355','AACTCGTCGATG','YATGCTGCCTCCCGTAGGAGT','Control','20061218','Control_mouse_I.D._355'],
+    ['PC.356','ACAGACCACTCA','YATGCTGCCTCCCGTAGGAGT','Control','20061126','Control_mouse_I.D._356'],
+    ['PC.481','ACCAGCGACTAG','YATGCTGCCTCCCGTAGGAGT','Control','20070314','Control_mouse_I.D._481'],
+    ['PC.593','AGCAGCACTTGT','YATGCTGCCTCCCGTAGGAGT','Control','20071210','Control_mouse_I.D._593'],
+    ['PC.607','AACTGTGCGTAC','YATGCTGCCTCCCGTAGGAGT','Fast','20071112','Fasting_mouse_I.D._607'],
+    ['PC.634','ACAGAGTCGGCT','YATGCTGCCTCCCGTAGGAGT','Fast','20080116','Fasting_mouse_I.D._634'],
+    ['PC.635','ACCGCAGAGTCA','YATGCTGCCTCCCGTAGGAGT','Fast','20080116','Fasting_mouse_I.D._635'],
+    ['PC.636','ACGGTGAGTGTC','YATGCTGCCTCCCGTAGGAGT','Fast','20080116','Fasting_mouse_I.D._636']]
 
-    def test_quantile(self):
-        """checks for correct quantile statistic values"""
-        
-        # suffle the data to be sure, it is getting sorted
-        sample_data = array(range(1, 11))
-        shuffle(sample_data)
-
-        # regular cases
-        expected_output = [1.9, 2.8, 3.25, 5.5, 7.75, 7.93]
-        list_of_quantiles = [0.1, 0.2, 0.25, 0.5, 0.75, 0.77]
-        output = quantile(sample_data, list_of_quantiles)
-        self.assertFloatEqual(expected_output, output)
-
-        sample_data = array([42, 32, 24, 57, 15, 34, 83, 24, 60, 67, 55, 17,
-            83, 17, 80, 65, 14, 34, 39, 53])
-        list_of_quantiles = [0.5]
-        output = quantile(sample_data, list_of_quantiles)
-        self.assertFloatEqual(output, median(sample_data))
-
-        # quantiles must be between [0, 1]
-        with self.assertRaises(AssertionError):
-            output = quantile(sample_data, [0.1, 0.2, -0.1, 2, 0.3, 0.5])
-
-        # quantiles must be a list or a numpy array
-        with self.assertRaises(AssertionError):
-            output = quantile(sample_data, 1)
-
-        # the data must be a list or a numpy array
-        with self.assertRaises(AssertionError):
-            output = quantile(1, [0])
-
-    def test__quantile(self):
-        """checks for correct quantiles according to R. type 7 algorithm"""
-        # regular cases
-        sample_data = array(range(25, 42))
-        self.assertFloatEqual(_quantile(sample_data, 0.5), median(sample_data))
-
-        # sorted data is assumed for this function
-        sample_data = array([ 0.17483293,  0.99891939,  0.81377467,  0.8137437 ,
-            0.51990174, 0.35521497,  0.98751461])
-        sample_data.sort()
-        self.assertFloatEqual(_quantile(sample_data, 0.10), 0.283062154)
-
-MAPPING_FILE_DATA = [\
-    ['PC.354','AGCACGAGCCTA','YATGCTGCCTCCCGTAGGAGT','Control','20061218','Control_mouse_I.D._354'],\
-    ['PC.355','AACTCGTCGATG','YATGCTGCCTCCCGTAGGAGT','Control','20061218','Control_mouse_I.D._355'],\
-    ['PC.356','ACAGACCACTCA','YATGCTGCCTCCCGTAGGAGT','Control','20061126','Control_mouse_I.D._356'],\
-    ['PC.481','ACCAGCGACTAG','YATGCTGCCTCCCGTAGGAGT','Control','20070314','Control_mouse_I.D._481'],\
-    ['PC.593','AGCAGCACTTGT','YATGCTGCCTCCCGTAGGAGT','Control','20071210','Control_mouse_I.D._593'],\
-    ['PC.607','AACTGTGCGTAC','YATGCTGCCTCCCGTAGGAGT','Fast','20071112','Fasting_mouse_I.D._607'],\
-    ['PC.634','ACAGAGTCGGCT','YATGCTGCCTCCCGTAGGAGT','Fast','20080116','Fasting_mouse_I.D._634'],\
-    ['PC.635','ACCGCAGAGTCA','YATGCTGCCTCCCGTAGGAGT','Fast','20080116','Fasting_mouse_I.D._635'],\
-    ['PC.636','ACGGTGAGTGTC','YATGCTGCCTCCCGTAGGAGT','Fast','20080116','Fasting_mouse_I.D._636']\
-]
-
-MAPPING_FILE_DATA_WITH_ALPHA_A = [\
-['PC.354', 'AGCACGAGCCTA', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061218', 'Control_mouse_I.D._354', '176.8', '0.35793814433', 'bin_2_of_4', '5.40341', '0.301036595418', 'bin_2_of_4'],\
-['PC.355', 'AACTCGTCGATG', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061218', 'Control_mouse_I.D._355', '127.0', '0.152577319588', 'bin_1_of_4', '4.50866', '0.0', 'bin_1_of_4'],\
-['PC.356', 'ACAGACCACTCA', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061126', 'Control_mouse_I.D._356', '189.9375', '0.412113402062', 'bin_2_of_4', '5.5103', '0.336999491964', 'bin_2_of_4'],\
-['PC.481', 'ACCAGCGACTAG', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20070314', 'Control_mouse_I.D._481', '223.58333333', '0.550859106515', 'bin_3_of_4', '6.26648', '0.59141452714', 'bin_3_of_4'],\
-['PC.593', 'AGCAGCACTTGT', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20071210', 'Control_mouse_I.D._593', '90.0', '0.0', 'bin_1_of_4', '4.84129', '0.111912604341', 'bin_1_of_4'],\
-['PC.607', 'AACTGTGCGTAC', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20071112', 'Fasting_mouse_I.D._607', '211.0', '0.498969072165', 'bin_2_of_4', '7.3172', '0.944926873089', 'bin_4_of_4'],\
-['PC.634', 'ACAGAGTCGGCT', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20080116', 'Fasting_mouse_I.D._634', '146.0', '0.230927835052', 'bin_1_of_4', '6.57543', '0.695360049525', 'bin_3_of_4'],\
-['PC.635', 'ACCGCAGAGTCA', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20080116', 'Fasting_mouse_I.D._635', '332.5', '1.0', 'bin_4_of_4', '7.48089', '1.0', 'bin_4_of_4'],\
+MAPPING_FILE_DATA_WITH_ALPHA_A = [
+['PC.354', 'AGCACGAGCCTA', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061218', 'Control_mouse_I.D._354', '176.8', '0.35793814433', 'bin_2_of_4', '5.40341', '0.301036595418', 'bin_2_of_4'],
+['PC.355', 'AACTCGTCGATG', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061218', 'Control_mouse_I.D._355', '127.0', '0.152577319588', 'bin_1_of_4', '4.50866', '0.0', 'bin_1_of_4'],
+['PC.356', 'ACAGACCACTCA', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061126', 'Control_mouse_I.D._356', '189.9375', '0.412113402062', 'bin_2_of_4', '5.5103', '0.336999491964', 'bin_2_of_4'],
+['PC.481', 'ACCAGCGACTAG', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20070314', 'Control_mouse_I.D._481', '223.58333333', '0.550859106515', 'bin_3_of_4', '6.26648', '0.59141452714', 'bin_3_of_4'],
+['PC.593', 'AGCAGCACTTGT', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20071210', 'Control_mouse_I.D._593', '90.0', '0.0', 'bin_1_of_4', '4.84129', '0.111912604341', 'bin_1_of_4'],
+['PC.607', 'AACTGTGCGTAC', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20071112', 'Fasting_mouse_I.D._607', '211.0', '0.498969072165', 'bin_2_of_4', '7.3172', '0.944926873089', 'bin_4_of_4'],
+['PC.634', 'ACAGAGTCGGCT', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20080116', 'Fasting_mouse_I.D._634', '146.0', '0.230927835052', 'bin_1_of_4', '6.57543', '0.695360049525', 'bin_3_of_4'],
+['PC.635', 'ACCGCAGAGTCA', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20080116', 'Fasting_mouse_I.D._635', '332.5', '1.0', 'bin_4_of_4', '7.48089', '1.0', 'bin_4_of_4'],
 ['PC.636', 'ACGGTGAGTGTC', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20080116', 'Fasting_mouse_I.D._636', '173.0', '0.342268041237', 'bin_2_of_4', '6.39901', '0.636003943167', 'bin_3_of_4']]
 
 MAPPING_FILE_DATA_WITH_ALPHA_B = [


### PR DESCRIPTION
Add alpha diversity data to a mapping file for use with other QIIME scripts, i. e. make_3d_plots.py. The resulting mapping file will contain three new columns per metric in the alpha diversity data; the first column being the raw value, the second being a normalized raw value and the third one a label classifying the bin where this value fits based on the normalized value.
