### PR TITLE
Fixed issue with RDP classifier's dereplication of taxa

### DIFF
--- a/qiime/assign_taxonomy.py
+++ b/qiime/assign_taxonomy.py
@@ -2,7 +2,8 @@
 
 __author__ = "Rob Knight, Greg Caporaso"
 __copyright__ = "Copyright 2011, The QIIME Project"
-__credits__ = ["Rob Knight", "Greg Caporaso", "Kyle Bittinger", "Antonio Gonzalez Pena", "David Soergel"]
+__credits__ = ["Rob Knight", "Greg Caporaso", "Kyle Bittinger",
+               "Antonio Gonzalez Pena", "David Soergel", "Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.5.0-dev"
 __maintainer__ = "Greg Caporaso"
@@ -597,15 +598,19 @@ class RdpTree(object):
                 yield node
 
     def dereplicate_taxa(self):
+        # We check that there are no duplicate taxon names (case insensitive)
+        # at a given depth. We must do a case insensitive check because the RDP
+        # classifier converts taxon names to lowercase when it checks for
+        # duplicates, and will throw an error otherwise.
         taxa_by_depth = {}
         for node in self.get_nodes():
             name = node.name
             depth = node.depth
             current_names = taxa_by_depth.get(depth, set())
-            if name in current_names:
+            if name.lower() in current_names:
                 node.name = name + _QIIME_RDP_TAXON_TAG + str(node.id)
             else:
-                current_names.add(name)
+                current_names.add(name.lower())
                 taxa_by_depth[depth] = current_names
 
     def get_rdp_taxonomy(self):

--- a/tests/test_assign_taxonomy.py
+++ b/tests/test_assign_taxonomy.py
@@ -5,7 +5,8 @@
 __author__ = "Greg Caporaso"
 __copyright__ = "Copyright 2011, The QIIME Project"
 #remember to add yourself if you make changes
-__credits__ = ["Greg Caporaso", "Kyle Bittinger", "David Soergel"]
+__credits__ = ["Greg Caporaso", "Kyle Bittinger", "David Soergel",
+               "Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.5.0-dev"
 __maintainer__ = "Greg Caporaso"
@@ -989,6 +990,17 @@ class RdpTreeTests(TestCase):
         c1 = t.children['a'].children['x']
         c2 = t.children['b'].children['x']
         self.assertNotEqual(c1.name, c2.name)
+
+        # Test case-insensitive dereplication.
+        t = RdpTree()
+        t.insert_lineage(['a', 'x'])
+        t.insert_lineage(['b', 'X'])
+        t.dereplicate_taxa()
+
+        c1 = t.children['a'].children['x']
+        c2 = t.children['b'].children['X']
+        self.assertTrue((c1.name == 'x' and c2.name != 'X') or
+                        (c1.name != 'x' and c2.name == 'X'))
 
     def test_get_rdp_taxonomy(self):
         t = RdpTree()


### PR DESCRIPTION
Fixed issue when the id-to-taxonomy map has duplicate _case-insensitive_ taxon names at the same depth.

The RDP classifier internally performs a case-insensitive check for duplicate taxon names at a given rank, and thus would throw an error when it hit this case.

This issue recently arose when testing out a new fungal database with the RDP classifier.

@kylebittinger, I'm especially interested in your feedback regarding this fix, as you're most familiar with the RDP classifier code.
