### PR TITLE
Fix for issue #469

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ QIIME 1.5.0-dev (changes since 1.5.0 go here)
 * compare_alpha_diversity.py now supports both parametric and nonparametric two sample t-tests (nonparametric is the default) with the new optional options -t/--test_type and -n/--num_permutations. Also fixed a bug that used the wrong degrees of freedom in the t-tests, yielding incorrect t statistics and p-values.
 * Removed tree method 'raxml' from make_phylogeny.py's choices for -t/--tree_method. Tree method 'raxml_v730' should now be used instead. RAxML v703 is no longer supported.
 * Minimum PyNAST version requirement upgraded to PyNAST 1.2.
+* make_distance_boxplots.py, make_distance_comparison_plots.py, and make_distance_histograms.py now correctly output TSV data files with .txt extension instead of .xls (this allows them to be opened easier in programs such as Excel).
 
 QIIME 1.5.0 (8 May 2012)
 ==================================

--- a/doc/tutorials/creating_distance_comparison_plots.rst
+++ b/doc/tutorials/creating_distance_comparison_plots.rst
@@ -33,7 +33,7 @@ This command will create a new output directory named :file:`tutorial_output`, w
 
 The first and second boxplots represent all within distances and all between distances, respectively. The first boxplot contains the distances within `Control` samples and the distances within `Fast` samples.  Likewise, the second boxplot contains the distances between `Control` and `Fast` samples. The next two boxplots represent the individual within distances and the final boxplot represents the individual between distances. Since there are only two possible states for the `Treatment` field (i.e. `Control` or `Fast`), the all between boxplot is the same as the individual between boxplot. If there were more possible field states, however, the all between boxplot may not always match the individual between boxplots because there will be more than one individual between boxplot contributing to the all between boxplot.  
 
-Next, open up the file :file:`Treatment_Stats.xls` in the :file:`tutorial_output` directory:
+Next, open up the file :file:`Treatment_Stats.txt` in the :file:`tutorial_output` directory:
 
 .. note::
 
@@ -57,7 +57,7 @@ This file is most easily viewed in a spreadsheet program such as Microsoft Excel
 
     make_distance_boxplots.py -m Fasting_Map.txt -d wf_bdiv_even146/unweighted_unifrac_dm.txt -f Treatment -o tutorial_output -n 999
 
-Open up the resulting file :file:`Treatment_Stats.xls`:
+Open up the resulting file :file:`Treatment_Stats.txt`:
 
 .. note::
 
@@ -85,7 +85,7 @@ To save the data used in the plots in a text file format, specify the --save_raw
 
     make_distance_boxplots.py -m Fasting_Map.txt -d wf_bdiv_even146/unweighted_unifrac_dm.txt -f Treatment -o tutorial_output --save_raw_data
 
-This will generate the file :file:`Treatment_Distances.xls` in the :file:`tutorial_output` directory, which contains the raw data used in the plots in a tab-separated file format. This file can then be imported into other programs, such as Excel, for easy viewing.
+This will generate the file :file:`Treatment_Distances.txt` in the :file:`tutorial_output` directory, which contains the raw data used in the plots in a tab-separated file format. This file can then be imported into other programs, such as Excel, for easy viewing.
 
 To create plots for multiple fields in the metadata mapping file, you can specify a list of fields using the same -f option that we used before to specify the `Treatment` field: ::
 

--- a/qiime/make_distance_histograms.py
+++ b/qiime/make_distance_histograms.py
@@ -553,7 +553,7 @@ def write_distance_files(group_distance_dict,dir_prefix = '', \
         pass
         
     for field, data in group_distance_dict.items(): #skip sample id field
-        fname = path.join(path_prefix, 'dist_' + field + '.xls')
+        fname = path.join(path_prefix, 'dist_' + field + '.txt')
         outfile = open(fname, 'w')
         for d in data:
             if subdir_prefix.endswith('pairs'):
@@ -668,7 +668,7 @@ def monte_carlo_group_distances(mapping_file, dmatrix_file, prefs, \
         else:
             groups = group_by_field(mapping, field)
         outfile = open(path.join(path_prefix,
-                                 'group_distances_'+field+'.xls'), 'w')
+                                 'group_distances_'+field+'.txt'), 'w')
         outfile.write('\t'.join(['Category_1a','Category_1b','Avg',\
             'Category_2a','Category_2b','Avg','t','p',\
             'p_greater','p_less','Iterations\n']))
@@ -748,7 +748,7 @@ def monte_carlo_group_distances_within_between(single_field, \
         field, distances in within_and_between.items()])
     
     outfile = open(path.join(path_prefix,
-                            'group_distances_within_and_between.xls'), 'w')
+                            'group_distances_within_and_between.txt'), 'w')
     outfile.write('\t'.join(['Comparison','Category_1','Avg',\
         'Comparison','Category_2','Avg','t','p',\
         'p_greater','p_less','Iterations\n']))

--- a/scripts/make_distance_boxplots.py
+++ b/scripts/make_distance_boxplots.py
@@ -321,7 +321,7 @@ def main():
 
         if not opts.suppress_significance_tests:
             sig_tests_f = open(join(
-                opts.output_dir, "%s_Stats.xls" % field), 'w')
+                opts.output_dir, "%s_Stats.txt" % field), 'w')
             sig_tests_results = all_pairs_t_test(plot_labels, plot_data,
                     tail_type=opts.tail_type,
                     num_permutations=opts.num_permutations)
@@ -331,7 +331,7 @@ def main():
         if opts.save_raw_data:
             # Write the raw plot data into a tab-delimited file.
             assert(len(plot_labels) == len(plot_data))
-            raw_data_fp = join(opts.output_dir, "%s_Distances.xls"
+            raw_data_fp = join(opts.output_dir, "%s_Distances.txt"
                                     % field)
             raw_data_f = open(raw_data_fp, 'w')
 

--- a/scripts/make_distance_comparison_plots.py
+++ b/scripts/make_distance_comparison_plots.py
@@ -360,7 +360,7 @@ def main():
             transparent=opts.transparent)
 
     if not opts.suppress_significance_tests:
-        sig_tests_f = open(join(opts.output_dir, "%s_Stats.xls" % field), 'w')
+        sig_tests_f = open(join(opts.output_dir, "%s_Stats.txt" % field), 'w')
 
         # Rearrange the plot data into a format suitable for all_pairs_t_test.
         sig_tests_labels = []
@@ -384,7 +384,7 @@ def main():
         assert (len(plot_x_axis_labels) == len(plot_data)), "The number of " +\
                 "labels do not match the number of points along the x-axis."
         raw_data_fp = join(opts.output_dir,
-                           "%s_Distance_Comparisons.xls" % field)
+                           "%s_Distance_Comparisons.txt" % field)
         raw_data_f = open(raw_data_fp, 'w')
 
         raw_data_f.write("#ComparisonGroup\tFieldState\tDistances\n")

--- a/tests/test_make_distance_histograms.py
+++ b/tests/test_make_distance_histograms.py
@@ -3,7 +3,7 @@
 
 __author__ = "Jeremy Widmann"
 __copyright__ = "Copyright 2011, The QIIME Project"
-__credits__ = ["Jeremy Widmann"]
+__credits__ = ["Jeremy Widmann", "Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.5.0-dev"
 __maintainer__ = "Jeremy Widmann"
@@ -346,7 +346,7 @@ class DistanceHistogramsTests(TestCase):
     def test_write_distance_files(self):
         """write_distance_files should return correct result.
         """
-        exp_path = self.working_dir+'distances/dist_Treatment.xls'
+        exp_path = self.working_dir+'distances/dist_Treatment.txt'
         write_distance_files(self.single_field_treatment,\
             dir_prefix=self.working_dir)
         self.assertEqual(open(exp_path,'U').read(),
@@ -394,7 +394,7 @@ class DistanceHistogramsTests(TestCase):
         """monte_carlo_group_distances should return correct result.
         """
         mc_group_dist_path = self.working_dir+\
-            'monte_carlo_group_distances/group_distances_Treatment.xls'
+            'monte_carlo_group_distances/group_distances_Treatment.txt'
         monte_carlo_group_distances(mapping_file=self.map_file,\
                                     dmatrix_file=self.dmat_file,\
                                     prefs=PREFS,\
@@ -432,7 +432,7 @@ class DistanceHistogramsTests(TestCase):
         """monte_carlo_group_distances_within_between should return correct.
         """
         mc_group_dist_path = self.working_dir+\
-            'monte_carlo_group_distances/group_distances_within_and_between.xls'
+            'monte_carlo_group_distances/group_distances_within_and_between.txt'
         monte_carlo_group_distances_within_between(\
             single_field=self.single_field_treatment,\
             paired_field=self.paired_field_treatment,\


### PR DESCRIPTION
make_distance_boxplots.py, make_distance_comparison_plots.py, and make_distance_histograms.py now correctly output TSV data files with .txt extension instead of .xls (this allows them to be opened easier in programs such as Excel).

This fixes issue #469. There will be a separate pull request to https://github.com/qiime/qiime_test_data shortly to update the output files.
