### PR TITLE
Changed print statement to raise an exception

### DIFF
--- a/scripts/core_qiime_analyses.py
+++ b/scripts/core_qiime_analyses.py
@@ -13,7 +13,6 @@ __status__ = "Development"
 
 from qiime.util import make_option
 from os import makedirs
-from optparse import OptionValueError
 from qiime.util import (load_qiime_config, 
                         parse_command_line_parameters, 
                         get_options_lookup)
@@ -156,8 +155,8 @@ def main():
         else:
             # Since the analysis can take quite a while, I put this check
             # in to help users avoid overwriting previous output.
-            raise OptionValueError,("Output directory already exists. Please "
-                "choose a different directory, or force overwrite with -f.")
+            option_parser.error("Output directory already exists. Please choose"
+                " a different directory, or force overwrite with -f.")
         
     if print_only:
         command_handler = print_commands


### PR DESCRIPTION
Should resolve issue #97.

Output looks like this:

```
Traceback (most recent call last):
  File "/Users/yoshikivazquezbaeza/git_sw/qiime/scripts/core_qiime_analyses.py", line 201, in <module>
    main()    
  File "/Users/yoshikivazquezbaeza/git_sw/qiime/scripts/core_qiime_analyses.py", line 159, in main
    raise OptionValueError,("Output directory already exists. Please "
optparse.OptionValueError: Output directory already exists. Please choose a different directory, or force overwrite with -f.
```
