### PR TITLE
Small Changes to Parallel Documentation

### DIFF
--- a/doc/tutorials/parallel_qiime.rst
+++ b/doc/tutorials/parallel_qiime.rst
@@ -18,6 +18,10 @@ The `cluster jobs` scripts that ship with QIIME are:
  * :doc:`../scripts/start_parallel_jobs_torque`
  * :doc:`../scripts/start_parallel_jobs_sc`
 
+A multicore or multithread machine can be set to use one of these files by setting your ``qiime_config`` file as follows (assuming that ``start_parallel_jobs.py`` is in your ``$PATH``)::
+
+	cluster_jobs_fp  start_parallel_jobs.py
+
 Enabling parallel runs in QIIME
 -------------------------------
 


### PR DESCRIPTION
As a follow up to Issue [#616](https://github.com/qiime/qiime/issues/616), I am submitting a small change to the documentation to show how to modify your `qiime_conf` to use the  existing `start_parallel_job` script.  I don't know if this is the best place to put this but I  think I would have benefitted from having this spelled out so maybe others would as well.

In my case this modification allows me to run the denoising in parallel on a workstation (not a cluster).

thanks,
zach cp
