### PR TITLE
use BIOM Table API instead of per-element lookups

### DIFF
--- a/qiime/otu_category_significance.py
+++ b/qiime/otu_category_significance.py
@@ -5,7 +5,7 @@ from __future__ import division
 __author__ = "Catherine Lozupone"
 __copyright__ = "Copyright 2011, The QIIME Project"
 __credits__ = ["Catherine Lozupone", "Jesse Stombaugh", "Dan Knights",
-               "Jai Ram Rideout"]
+               "Jai Ram Rideout", "Daniel McDonald"]
 __license__ = "GPL"
 __version__ = "1.6.0-dev"
 __maintainer__ = "Catherine Lozupone"


### PR DESCRIPTION
Tests pass for test_otu_category_significance.py but am getting some output over stdout. Both warning messages appear to have been produced present prior to this pull request. This is in regards to #648 

17:09:04 tests@otu_cat_sig_perfbug$ python test_otu_category_significance.py 
......................Warning: sample1 is in the  sample mapping file but not the OTU table
...../Users/mcdonald/ResearchWork/software/pycogent/cogent/maths/stats/test.py:1159: RuntimeWarning: invalid value encountered in double_scalars
  F = between_MS/within_MS
## ..

Ran 29 tests in 0.111s

OK
