### PR TITLE
Update collate_alpha.py to avoid directories

### DIFF
--- a/scripts/collate_alpha.py
+++ b/scripts/collate_alpha.py
@@ -87,8 +87,7 @@ def main():
         os.makedirs(output_dir)
     
     file_names = os.listdir(input_dir)
-    file_names = [fname for fname in file_names if not fname.startswith('.')]
-    file_names = [fname for fname in file_names if os.path.isfile(fname)]
+    file_names = [fname for fname in file_names if not fname.startswith('.') and os.path.isfile(fname)]
 
     if example_filepath is None:
         # table row is base_name, seqs_per_sam, iters, ext


### PR DESCRIPTION
Brief: Update the collate alpha script to ignore directories. Empty directories can be left over from previous (interrupted) `alpha_diversity.py` runs.

Longer: I was running the `alpha_diversity.py` script and was getting the following error:

```
/opt/python2.7/bin/python2.7 /home/qiime/bin/collate_alpha.py -i ../qiime_output/alpha//alpha_div/ -o ../qiime_output/alpha//alpha_div_collated/
[qiime@bradybeast qiime_output]$ /opt/python2.7/bin/python2.7 /home/qiime/bin/collate_alpha.py -i ../qiime_output/alpha//alpha_div/ -o ../qiime_output/alpha//alpha_div_collated/ 
Traceback (most recent call last):
  File "/home/qiime/bin/collate_alpha.py", line 125, in <module>
    main()
  File "/home/qiime/bin/collate_alpha.py", line 94, in main
    file_name_table = map(parse_rarefaction_fname, file_names)
  File "/home/qiime/lib/qiime/parse.py", line 378, in parse_rarefaction_fname
    iters = int(root_list.pop())
ValueError: invalid literal for int() with base 10: ''
```

After checking my mapping file and looking to see anything funny about the biom table I found the problem. I had stopped a previous version of the `alpha_diversity.py` script and it had left a series of empty temporary folders in the `alpha_div` folder.  `Collate_alpha.py` tries to read the folders as if they were files and it fails. If you delete the temp folders,  it runs fine. My fix is to simply check if the results of `os.listdir()` is a file or a folder and to discard the folders.
