### PR TITLE
Resolves issue #686.

### DIFF
--- a/qiime/compare_alpha_diversity.py
+++ b/qiime/compare_alpha_diversity.py
@@ -168,8 +168,11 @@ def compare_alpha_diversities(rarefaction_lines, mapping_lines, category, depth,
             elif test_type == 'nonparametric':
                 obs_t, _, _, p_val = mc_t_two_sample(i,j, 
                     permutations=num_permutations)
-                p_val = float(format_p_value_for_num_iters(p_val, 
-                    num_iters=num_permutations))
+                if p_val != None: 
+                    p_val = float(format_p_value_for_num_iters(p_val, 
+                        num_iters=num_permutations))
+                elif p_val ==  None: #None will error in format_p_val
+                    obs_t, p_val = None, None
             else:
                 raise ValueError("Invalid test type '%s'." % test_type)
             results[t_key]= (obs_t,p_val)

--- a/scripts/compare_alpha_diversity.py
+++ b/scripts/compare_alpha_diversity.py
@@ -42,7 +42,7 @@ controlled by this script; when multiple_rarefactions.py is called, the -n optio
 specifies the number of iterations that have occurred. The multiple comparison
 correction takes into account the number of between group comparisons.
 
-If t-scores and/or p-values are None for any of your comparisons there are two
+If t-scores and/or p-values are None for any of your comparisons there are three
 possible reasons. The first is that there were undefined values in your collated
 alpha diversity input file. This occurs if there were too few sequences in one 
 or more of the samples in the groups involved in those comparisons to compute 
@@ -53,6 +53,9 @@ The second is that you had some comparison where each treatment was represented
 by only a single sample. It is not possible to perform a t_two_sample test on 
 two samples each of length 1, so it will give you None,None for tval,pval 
 instead.
+The third possibility occurs when using the nonparamteric t test with small 
+datasets where the monte carlo simulations return no p-value because the
+distribution of the data has almost no variance.
 The multiple comparisons correction will not penalize you for comparisons that
 return as None regardless of origin. 
 """


### PR DESCRIPTION
Updated 3 lines in compare_alpha_diversity.py to check if p_val or obs_t return as None because of low variance data passed to mc_t_two_sample. Updated the script documentation to identify this third source of error (why you would get None, None for pval, tval).

Note: I cannot reproduce the error you are finding @gregcaporaso so I have inspected the code carefully and believe this will resolve the error. If you would like to send me the test data thats failing for you, would be happy to test it. 
