### PR TITLE
Changed timeout from 120 to 240 seconds.

### DIFF
--- a/tests/test_core_diversity_analyses.py
+++ b/tests/test_core_diversity_analyses.py
@@ -64,7 +64,7 @@ class CoreDiversityAnalysesTests(TestCase):
         
         # Define number of seconds a test can run for before timing out 
         # and failing
-        initiate_timeout(120)
+        initiate_timeout(240)
 
     
     def tearDown(self):


### PR DESCRIPTION
The parallel test was timing out for @ElDeveloper and I.
