### PR TITLE
Solves issue #758 -- a truly monumental commit

### DIFF
--- a/doc/tutorials/open_reference_illumina_processing.rst
+++ b/doc/tutorials/open_reference_illumina_processing.rst
@@ -38,7 +38,7 @@ When working with Illumina data you typically want to filter singleton OTUs (i.e
 
 In QIIME 1.4.0-dev and later, you can filter singleton OTUs with this command::
 	
-	filter_otus_from_otu_table.py -i $PWD/ucr/otu_table.biom -o $PWD/ucr/otu_table_mc2.biom -c 2
+	filter_otus_from_otu_table.py -i $PWD/ucr/otu_table.biom -o $PWD/ucr/otu_table_mc2.biom -n 2
 
 You'll notice that depending on your version of QIIME, the extension on your OTU table file will differ. In QIIME 1.4.0 and earlier, it will be ``.txt``. In QIIME 1.4.0-dev and later it will be ``.biom``. We'll continue this example assuming that your OTU table ends with ``.txt`` (if you're working with QIIME 1.4.0-dev or later, you likely decided to go with option 2 for OTU picking).
 


### PR DESCRIPTION
this addresses issue #758

wanted to make sure the tutorial was exactly correct so I searched for the first time that 'filter_otus_from_otu_table.py' was mentioned in the revision history. 

found 98a64044258cfeda2d89b7f6de955e8a998feb9f as the revision that added filter_otus_from_otu_table.py. there was an earlier commit (week time difference) where the filter_otus_from_otu_table.py did not yet exist, but the version of qiime was still considered 1.4.0-dev (that commit is 1ec285922eb00251a86591eba73dbe43749f4392). 

this means that the instructions on http://qiime.org/tutorials/open_reference_illumina_processing.html are wrong if someone has a 1.4 version checked out between Dec 14th and Dec 21st 2011. this is probably not a big issue. 
