### PR TITLE
Allow minimum rather than exact version of R, see issue #624

### DIFF
--- a/scripts/print_qiime_config.py
+++ b/scripts/print_qiime_config.py
@@ -702,7 +702,6 @@ class Qiime_config(TestCase):
         version_string = stdout.strip()
         try:
             version = tuple(map(int,version_string.split('.')))
-#             pass_test = version in acceptable_version
             pass_test = False
             if version[0] == minimum_version[0]:
                 if version[1] == minimum_version[1]:


### PR DESCRIPTION
No need for QIIME to require exact version or R. Now requires minimum version of R (2.12.0). 
