### PR TITLE
Fixing option types and example definition

### DIFF
--- a/qiime/make_bootstrapped_tree.py
+++ b/qiime/make_bootstrapped_tree.py
@@ -46,6 +46,4 @@ def write_pdf_bootstrap_tree(tree, output_f, hits_dict):
         width=700
     if height<700:
         height=700
-    if not output_f[-4:] == ".pdf":
-        output_f = output_f + ".pdf"
     t.drawToPDF(output_f, width, height, edge_color_callback=f) 

--- a/scripts/make_bootstrapped_tree.py
+++ b/scripts/make_bootstrapped_tree.py
@@ -28,7 +28,7 @@ script_info['script_usage']=[]
 script_info['script_usage'].append(("""Example:""",
 """In this example, the user supplies a tree file and a text file\
  containing the jackknife support information, which results in a pdf file:""",
- """%prog -m master_tree.tre -s jackknife_support.txt -o jackknife_samples.pdf"""))
+"""%prog -m master_tree.tre -s jackknife_support.txt -o jackknife_samples.pdf"""))
 script_info['output_description']="""The result of this script is a pdf file."""
 script_info['required_options']=[\
  make_option('-m', '--master_tree', type='existing_filepath',
@@ -36,8 +36,7 @@ script_info['required_options']=[\
  make_option('-s', '--support', type='existing_filepath',
  	help='This is the path to the bootstrap support file'),
  make_option('-o', '--output_file', type='new_filepath',
- 	help="This is the filename where the output should be written. \
- 	If the suffix does not contain .pdf, then it will be attached")
+ 	help="This is the filename where the output should be written.")
 ]
 script_info['optional_options']=[]
 script_info['version'] = __version__


### PR DESCRIPTION
This pull request solves item `make_bootstrapped_tree.py` of #632

On the other hand, I think this script won't work in Galaxy because it automatically appends `.pdf` to the output file if it is not defined. This functionality is implemented in `cogent` and that's why I haven't make any change to solve that.

On the other hand, how much important is this script and how many people are still using it?
