### PR TITLE
Fixing --dir-prefix option type of split_libraries.py

### DIFF
--- a/scripts/split_libraries.py
+++ b/scripts/split_libraries.py
@@ -4,7 +4,9 @@ from __future__ import division
 
 __author__ = "Rob Knight and Micah Hamady"
 __copyright__ = "Copyright 2011, The QIIME Project"
-__credits__ =  ["Rob Knight", "Micah Hamady", "Greg Caporaso", "Kyle Bittinger","Jesse Stombaugh","William Walters", "Jens Reeder"] #remember to add yourself
+__credits__ =  ["Rob Knight", "Micah Hamady", "Greg Caporaso", "Kyle Bittinger",
+        "Jesse Stombaugh","William Walters", "Jens Reeder",
+        "Jose Antonio Navas Molina"] #remember to add yourself
 __license__ = "GPL"
 __version__ = "1.6.0-dev"
 __maintainer__ = "William Walters"
@@ -20,38 +22,155 @@ from qiime.split_libraries import preprocess
 options_lookup = get_options_lookup()
 
 script_info={}
-script_info['brief_description']="""Split libraries according to barcodes specified in mapping file"""
-script_info['script_description']="""Since newer sequencing technologies provide many reads per run (e.g. the 454 GS FLX Titanium series can produce 400-600 million base pairs with 400-500 base pair read lengths) researchers are now finding it useful to combine multiple samples into a single 454 run. This multiplexing is achieved through the application of a pyrosequencing-tailored nucleotide barcode design (described in (Parameswaran et al., 2007)). By assigning individual, unique sample specific barcodes, multiple sequencing runs may be performed in parallel and the resulting reads can later be binned according to sample. The script %prog performs this task, in addition to several quality filtering steps including user defined cut-offs for: sequence lengths; end-trimming; minimum quality score. To summarize, by using the fasta, mapping, and quality files, the program %prog will parse sequences that meet user defined quality thresholds and then rename each read with the appropriate Sample ID, thus formatting the sequence data for downstream analysis. If a combination of different sequencing technologies are used in any particular study, %prog can be used to perform the quality-filtering for each library individually and the output may then be combined.
+script_info['brief_description']="""Split libraries according to barcodes\
+ specified in mapping file"""
+script_info['script_description']="""Since newer sequencing technologies\
+ provide many reads per run (e.g. the 454 GS FLX Titanium series can produce\
+ 400-600 million base pairs with 400-500 base pair read lengths) researchers\
+ are now finding it useful to combine multiple samples into a single 454 run.\
+ This multiplexing is achieved through the application of a\
+ pyrosequencing-tailored nucleotide barcode design (described in (Parameswaran\
+ et al., 2007)). By assigning individual, unique sample specific barcodes,\
+ multiple sequencing runs may be performed in parallel and the resulting reads\
+ can later be binned according to sample. The script %prog performs this task,\
+ in addition to several quality filtering steps including user defined cut-offs\
+ for: sequence lengths; end-trimming; minimum quality score. To summarize, by\
+ using the fasta, mapping, and quality files, the program %prog will parse\
+ sequences that meet user defined quality thresholds and then rename each read\
+ with the appropriate Sample ID, thus formatting the sequence data for\
+ downstream analysis. If a combination of different sequencing technologies are\
+ used in any particular study, %prog can be used to perform the\
+ quality-filtering for each library individually and the output may then be\
+ combined.
 
-Sequences from samples that are not found in the mapping file (no corresponding barcode) and sequences without the correct primer sequence will be excluded. Additional scripts can be used to exclude sequences that match a given reference sequence (e.g. the human genome; exclude_seqs_by_blast.py) and/or sequences that are flagged as chimeras (identify_chimeric_seqs.py).
+Sequences from samples that are not found in the mapping file (no corresponding\
+ barcode) and sequences without the correct primer sequence will be excluded.\
+ Additional scripts can be used to exclude sequences that match a given\
+ reference sequence (e.g. the human genome; exclude_seqs_by_blast.py)\
+ and/or sequences that are flagged as chimeras (identify_chimeric_seqs.py).
 """
 script_info['script_usage']=[]
-script_info['script_usage'].append(("""Standard Example:""","""Using a single 454 run, which contains a single FASTA, QUAL, and mapping file while using default parameters and outputting the data into the Directory "Split_Library_Output":""","""%prog -m Mapping_File.txt -f 1.TCA.454Reads.fna -q 1.TCA.454Reads.qual -o Split_Library_Output/"""))
-script_info['script_usage'].append(("""Multiple FASTA and QUAL Files Example:""","""For the case where there are multiple FASTA and QUAL files, the user can run the following comma-separated command as long as there are not duplicate barcodes listed in the mapping file:""","""%prog -m Mapping_File.txt -f 1.TCA.454Reads.fna,2.TCA.454Reads.fna -q 1.TCA.454Reads.qual,2.TCA.454Reads.qual -o Split_Library_Output_comma_separated/"""))
-script_info['script_usage'].append(("""Duplicate Barcode Example:""","""An example of this situation would be a study with 1200 samples. You wish to have 400 samples per run, so you split the analysis into three runs and reuse barcoded primers (you only have 600). After initial analysis you determine a small subset is underrepresented (<500 sequences per samples) and you boost the number of sequences per sample for this subset by running a fourth run. Since the same sample IDs are in more than one run, it is likely that some sequences will be assigned the same unique identifier by %prog when it is run separately on the four different runs, each with their own barcode file. This will cause a problem in file concatenation of the four different runs into a single large file. To avoid this, you can use the '-s' parameter which defines a start index for %prog. From experience, most FLX runs (when combining both files for a single plate) will have 350,000 to 650,000 sequences. Thus, if Run 1 for %prog uses '-n 1000000', Run 2 uses '-n 2000000', etc., then you are guaranteed to have unique identifiers after concatenating the results of multiple FLX runs. With newer technologies you will just need to make sure that your start index spacing is greater than the potential number of sequences.
+script_info['script_usage'].append(("""Standard Example:""",
+"""Using a single 454 run, which contains a single FASTA, QUAL, and mapping\
+ file while using default parameters and outputting the data into the Directory\
+ "Split_Library_Output":""",
+"""%prog -m Mapping_File.txt -f 1.TCA.454Reads.fna -q 1.TCA.454Reads.qual\
+ -o Split_Library_Output/"""))
+script_info['script_usage'].append(("""Multiple FASTA and QUAL Files Example:""",
+"""For the case where there are multiple FASTA and QUAL files, the user can run\
+ the following comma-separated command as long as there are not duplicate\
+ barcodes listed in the mapping file:""",
+"""%prog -m Mapping_File.txt -f 1.TCA.454Reads.fna,2.TCA.454Reads.fna\
+ -q 1.TCA.454Reads.qual,2.TCA.454Reads.qual\
+ -o Split_Library_Output_comma_separated/"""))
+script_info['script_usage'].append(("""Duplicate Barcode Example:""",
+"""An example of this situation would be a study with 1200 samples. You wish to\
+ have 400 samples per run, so you split the analysis into three runs and reuse\
+ barcoded primers (you only have 600). After initial analysis you determine a\
+ small subset is underrepresented (<500 sequences per samples) and you boost\
+ the number of sequences per sample for this subset by running a fourth run.\
+ Since the same sample IDs are in more than one run, it is likely that some\
+ sequences will be assigned the same unique identifier by %prog when it is run\
+ separately on the four different runs, each with their own barcode file. This\
+ will cause a problem in file concatenation of the four different runs into a\
+ single large file. To avoid this, you can use the '-s' parameter which defines\
+ a start index for %prog. From experience, most FLX runs (when combining both\
+ files for a single plate) will have 350,000 to 650,000 sequences. Thus, if Run\
+ 1 for %prog uses '-n 1000000', Run 2 uses '-n 2000000', etc., then you are\
+ guaranteed to have unique identifiers after concatenating the results of\
+ multiple FLX runs. With newer technologies you will just need to make sure\
+ that your start index spacing is greater than the potential number of\
+ sequences.
 
-To run %prog, you will need two or more (depending on the number of times the barcodes were reused) separate mapping files (one for each Run, for example one for Run1 and another one for Run2), then you can run %prog using the FASTA and mapping file for Run1 and FASTA and mapping file for Run2. Once you have run split libraries on each file independently, you can concatenate (e.g. using the 'cat' command) the sequence files that were generated by %prog. You can also concatenate the mapping files, since the barcodes are not necessary for downstream analyses, unless the same sample IDs are found in multiple mapping files.
+To run %prog, you will need two or more (depending on the number of times the\
+ barcodes were reused) separate mapping files (one for each Run, for example\
+ one for Run1 and another one for Run2), then you can run %prog using the FASTA\
+ and mapping file for Run1 and FASTA and mapping file for Run2. Once you have\
+ run split libraries on each file independently, you can concatenate (e.g.\
+ using the 'cat' command) the sequence files that were generated by %prog. You\
+ can also concatenate the mapping files, since the barcodes are not necessary\
+ for downstream analyses, unless the same sample IDs are found in multiple\
+ mapping files.
 
-Run %prog on Run 1:""","""%prog -m Mapping_File.txt -f 1.TCA.454Reads.fna -q 1.TCA.454Reads.qual -o Split_Library_Run1_Output/ -n 1000000"""))
-script_info['script_usage'].append(("""""","""Run %prog on Run 2. The resulting FASTA files from Run 1 and Run 2 can then be concatenated using the 'cat' command (e.g. cat Split_Library_Run1_Output/seqs.fna Split_Library_Run2_Output/seqs.fna > Combined_seqs.fna) and used in downstream analyses.""","""%prog -m Mapping_File.txt -f 2.TCA.454Reads.fna -q 2.TCA.454Reads.qual -o Split_Library_Run2_Output/ -n 2000000"""))
-script_info['script_usage'].append(("""Barcode Decoding Example:""","""The standard barcode types supported by %prog are golay (Length: 12 NTs) and hamming (Length: 8 NTs). For situations where the barcodes are of a different length than golay and hamming, the user can define a generic barcode type "-b" as an integer, where the integer is the length of the barcode used in the study.
+Run %prog on Run 1:""",
+"""%prog -m Mapping_File.txt -f 1.TCA.454Reads.fna -q 1.TCA.454Reads.qual\
+ -o Split_Library_Run1_Output/ -n 1000000"""))
+script_info['script_usage'].append(("""""",
+"""Run %prog on Run 2. The resulting FASTA files from Run 1 and Run 2 can then\
+ be concatenated using the 'cat' command (e.g.\
+ cat Split_Library_Run1_Output/seqs.fna Split_Library_Run2_Output/seqs.fna >\
+ Combined_seqs.fna) and used in downstream analyses.""",
+"""%prog -m Mapping_File.txt -f 2.TCA.454Reads.fna -q 2.TCA.454Reads.qual\
+ -o Split_Library_Run2_Output/ -n 2000000"""))
+script_info['script_usage'].append(("""Barcode Decoding Example:""",
+"""The standard barcode types supported by %prog are golay (Length: 12 NTs) and\
+ hamming (Length: 8 NTs). For situations where the barcodes are of a different\
+ length than golay and hamming, the user can define a generic barcode type "-b"\
+ as an integer, where the integer is the length of the barcode used in the study.
 
-Note: When analyzing large datasets (>100,000 seqs), users may want to use a generic barcode type, even for length 8 and 12 NTs, since the golay and hamming decoding processes can be computationally intensive, which causes the script to run slow. Barcode correction can be disabled with the -c option if desired.
+Note: When analyzing large datasets (>100,000 seqs), users may want to use a\
+ generic barcode type, even for length 8 and 12 NTs, since the golay and\
+ hamming decoding processes can be computationally intensive, which causes the\
+ script to run slow. Barcode correction can be disabled with the -c option if\
+ desired.
 
-For the case where the 8 base pair barcodes were used, you can use the following command:""","""%prog -m Mapping_File_8bp_barcodes.txt -f 1.TCA.454Reads.fna -q 1.TCA.454Reads.qual -o split_Library_output_8bp/ -b 8"""))
-script_info['script_usage'].append(("""Linkers and Primers:""","""The linker and primer sequence (or all the degenerate possibilities) are associated with each barcode from the mapping file. If a barcode cannot be identified, all the possible primers in the mapping file are tested to find a matching sequence. Using truncated forms of the same primer can lead to unexpected results for rare circumstances where the barcode cannot be identified and the sequence following the barcode matches multiple primers.
+For the case where the 8 base pair barcodes were used, you can use the\
+ following command:""",
+ """%prog -m Mapping_File_8bp_barcodes.txt -f 1.TCA.454Reads.fna\
+  -q 1.TCA.454Reads.qual -o split_Library_output_8bp/ -b 8"""))
+script_info['script_usage'].append(("""Linkers and Primers:""",
+"""The linker and primer sequence (or all the degenerate possibilities) are\
+ associated with each barcode from the mapping file. If a barcode cannot be\
+ identified, all the possible primers in the mapping file are tested to find a\
+ matching sequence. Using truncated forms of the same primer can lead to\
+ unexpected results for rare circumstances where the barcode cannot be\
+ identified and the sequence following the barcode matches multiple primers.
 
-In many cases, sequence reads are long enough to sequence through the reverse primer and sequencing adapter.  To remove these primers and all following sequences, the -z option can be used.  By default, this option is set to 'disable'.  If it is set to 'truncate_only', split_libraries will trim the primer and any sequence following it if the primer is found.  If the 'truncate_remove' option is set, %prog will trim the primer if found, and will not write the sequence if the primer is not found. The allowed mismatches for the reverse primer are set with the --reverse_primer_mismatches parameter (default 0).  To use reverse primer removal, one must include a 'ReversePrimer' column in the mapping file, with the reverse primer recorded in the 5' to 3' orientation.
+In many cases, sequence reads are long enough to sequence through the reverse\
+ primer and sequencing adapter.  To remove these primers and all following\
+ sequences, the -z option can be used.  By default, this option is set to\
+ 'disable'.  If it is set to 'truncate_only', split_libraries will trim the\
+ primer and any sequence following it if the primer is found.  If the\
+ 'truncate_remove' option is set, %prog will trim the primer if found, and will\
+ not write the sequence if the primer is not found. The allowed mismatches for\
+ the reverse primer are set with the --reverse_primer_mismatches parameter\
+ (default 0).  To use reverse primer removal, one must include a\
+ 'ReversePrimer' column in the mapping file, with the reverse primer recorded\
+ in the 5' to 3' orientation.
 
-Example reverse primer removal, where primers are trimmed if found, and sequence is written unchanged if not found.  Mismatches are increased to 1 from the default 0:""","""%prog -m Mapping_File_reverse_primer.txt -f 1.TCA.454Reads.fna -q 1.TCA.454Reads.qual -o split_libraries_output_revprimer/ --reverse_primer_mismatches 1 -z truncate_only"""))
+Example reverse primer removal, where primers are trimmed if found, and\
+ sequence is written unchanged if not found.  Mismatches are increased to 1\
+ from the default 0:""",
+"""%prog -m Mapping_File_reverse_primer.txt -f 1.TCA.454Reads.fna\
+ -q 1.TCA.454Reads.qual -o split_libraries_output_revprimer/\
+ --reverse_primer_mismatches 1 -z truncate_only"""))
 
 script_info['output_description']="""Three files are generated by %prog:
 
-1. .fna file (e.g. seqs.fna) - This is a FASTA file containing all sequences which meet the user-defined parameters, where each sequence identifier now contains its corresponding sample id from mapping file.
+1. .fna file (e.g. seqs.fna) - This is a FASTA file containing all sequences\
+ which meet the user-defined parameters, where each sequence identifier now\
+ contains its corresponding sample id from mapping file.
 
-2. histograms.txt- This contains the counts of sequences with a particular length.
+2. histograms.txt- This contains the counts of sequences with a particular\
+ length.
 
-3. split_library_log.txt - This file contains a summary of the %prog analysis. Specifically, this file includes information regarding the number of sequences that pass quality control (number of seqs written) and how these are distributed across the different samples which, through the use of bar-coding technology, would have been pooled into a single 454 run. The number of sequences that pass quality control will depend on length restrictions, number of ambiguous bases, max homopolymer runs, barcode check, etc. All of these parameters are summarized in this file. If raw sequences do not meet the specified quality thresholds they will be omitted from downstream analysis. Since we never see a perfect 454 sequencing run, the number of sequences written should always be less than the number of raw sequences. The number of sequences that are retained for analysis will depend on the quality of the 454 run itself in addition to the default data filtering thresholds in the %prog script. The default parameters (minimum quality score = 25, minimum/maximum length = 200/1000, no ambiguous bases allowed, no mismatches allowed in primer sequence) can be adjusted to meet the user's needs.
+3. split_library_log.txt - This file contains a summary of the %prog analysis.\
+ Specifically, this file includes information regarding the number of sequences\
+ that pass quality control (number of seqs written) and how these are\
+ distributed across the different samples which, through the use of bar-coding\
+ technology, would have been pooled into a single 454 run. The number of\
+ sequences that pass quality control will depend on length restrictions, number\
+ of ambiguous bases, max homopolymer runs, barcode check, etc. All of these\
+ parameters are summarized in this file. If raw sequences do not meet the\
+ specified quality thresholds they will be omitted from downstream analysis.\
+ Since we never see a perfect 454 sequencing run, the number of sequences\
+ written should always be less than the number of raw sequences. The number of\
+ sequences that are retained for analysis will depend on the quality of the 454\
+ run itself in addition to the default data filtering thresholds in the %prog\dir_prefix
+dir_prefix
+ script. The default parameters (minimum quality score = 25, minimum/maximum\
+ length = 200/1000, no ambiguous bases allowed, no mismatches allowed in primer\
+ sequence) can be adjusted to meet the user's needs.
 """
 script_info['required_options']=[\
     make_option('-m', '--map', dest='map_fname', type='existing_filepath',
@@ -107,7 +226,7 @@ script_info['optional_options']=[\
         'number representing the length of the barcode, such as -b 4. '+\
         ' [default: %default]'),
 
-    make_option('-o', '--dir-prefix', default='.', type='string',
+    make_option('-o', '--dir-prefix', default='.', type='new_dirpath',
         help='directory prefix for output files [default: %default]'),
 
     make_option('-e', '--max-barcode-errors', dest='max_bc_errors',


### PR DESCRIPTION
Fixes item `split_libraries.py` item of #632
