### PR TITLE
Upped timeouts of some workflow tests.

### DIFF
--- a/tests/test_workflow/test_core_diversity_analyses.py
+++ b/tests/test_workflow/test_core_diversity_analyses.py
@@ -61,7 +61,7 @@ class CoreDiversityAnalysesTests(TestCase):
         
         # Define number of seconds a test can run for before timing out 
         # and failing
-        initiate_timeout(240)
+        initiate_timeout(420)
 
     
     def tearDown(self):

--- a/tests/test_workflow/test_downstream.py
+++ b/tests/test_workflow/test_downstream.py
@@ -63,7 +63,7 @@ class DownstreamWorkflowTests(TestCase):
         self.saved_stderr = sys.stderr
         sys.stderr = StringIO()
         
-        initiate_timeout(60)
+        initiate_timeout(120)
     
     def tearDown(self):
         """ """


### PR DESCRIPTION
In an effort to use smaller Jenkins EC2 instances (e.g. m1.large), we've been seeing some tests timing out. These new timeouts seem to clear up the issue.
