### PR TITLE
addresses one of the stochastic failures noted in #864

### DIFF
--- a/tests/test_workflow/test_pick_open_reference_otus.py
+++ b/tests/test_workflow/test_pick_open_reference_otus.py
@@ -589,10 +589,10 @@ class PickSubsampledReferenceOtusThroughOtuTableTests(TestCase):
         otu_table = parse_biom_table(open(otu_table_fp,'U'))
         for row in otu_table.iterObservationData():
             self.assertTrue(sum(row) >= 2,"Singleton OTU detected in OTU table.")
-        # number of OTUs in final OTU table equals the number of seequences in
+        # number of OTUs in final OTU table equals the number of sequences in
         # the alignment...
         self.assertEqual(len(otu_table.ObservationIds),count_seqs(aln_fp)[0])
-        # ... and that number is either 5 or 6 (it can vary due to the random 
+        # ... and that number is either 4, 5 or 6 (it can vary due to the random 
         # subsampling)
         num_obs_ids = len(otu_table.ObservationIds)
         self.assertTrue(4 <= num_obs_ids <= 6,
@@ -627,12 +627,11 @@ class PickSubsampledReferenceOtusThroughOtuTableTests(TestCase):
          "Failure OTU (wf.test.otu.ReferenceOTU0) is not in the final OTU map.")
 
         # confirm that number of tips in the tree is the same as the number of sequences
-        # in the alignment, and that number is the same as the number of otus (it can vary due to the random 
-        # subsampling)
+        # in the alignment (and we already checked that we're happy with that number
+        # above when it was compared to the number of OTUs)
         num_tree_tips = len(LoadTree(tree_fp).tips())
         num_align_seqs = LoadSeqs(aln_fp).getNumSeqs()
         self.assertEqual(num_tree_tips,num_align_seqs)
-        self.assertTrue(num_obs_ids,num_tree_tips)
         
         # OTU table without singletons or pynast failures has same number of 
         # otus as there are aligned sequences


### PR DESCRIPTION
This change reduces the frequency of the first stochastic failure noted in #864, so partially addresses that issue. We're seeing more variability in the number of OTUs from usearch61, so needed to expand the allow range in this test a little bit. I'm not exactly sure why we're seeing more variability, but I did notice that number of OTUs can differ from uclust in my notes on comparing the methods in #848. 

When I ran this test 25 times locally, I had 2 failures prior to this change and 0 failures following this change. 
