### PR TITLE
Added support for non-diagonal zeros in Moran's I.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@ QIIME 1.6.0-dev (changes since QIIME 1.6.0 go here)
 * make_distance_comparison_plots.py now supports auto-sizing of distribution plots via --distribution_width (which is the new default) and better handles numeric label types with very large or small ranges (e.g. elevation) by scaling x-axis units to [1, (number of data points)]. --group_spacing has been removed in favor of the new auto-sizing feature.
 * per_library_stats.py removed in favor of biom-format's print_biom_table_summary.py.
 * Add SourceTracker tutorial, and changed QIIME to depend on SourceTracker 0.9.5 (which is modified to facilitate use with QIIME).
-
+* Moran's I (in compare_categories.py) now supports identical samples (i.e. zeros in the distance matrix that aren't on the diagonal).
 
 QIIME 1.6.0 (18 Dec 2012)
 =========================

--- a/qiime/support_files/R/morans_i.r
+++ b/qiime/support_files/R/morans_i.r
@@ -47,9 +47,12 @@ distmat <- load.qiime.distance.matrix(opts$distmat)
 qiime.data <- remove.nonoverlapping.samples(map=map, distmat=distmat)
 
 # run s
-# use inverse distance as weight
+# use inverse distance as weight. Set all zeros to very small number, otherwise
+# Moran.I will error out.
+qiime.data$distmat[qiime.data$distmat == 0] <- .Machine$double.eps
 weights = 1/qiime.data$distmat
-# set diagonal to zero
+
+# set diagonal back to zero
 diag(weights) <- 0
 
 results <- Moran.I(x=qiime.data$map[[opts$category]],weight=weights)

--- a/tests/test_compare_categories.py
+++ b/tests/test_compare_categories.py
@@ -35,11 +35,17 @@ class CompareCategoriesTests(TestCase):
         self.dirs_to_remove.append(self.test_dir)
 
         # Create input files under our temp dir.
-        self.dm_fp = join(self.test_dir, 'dm.txt')
-        dm_f = open(self.dm_fp, 'w')
-        dm_f.write(dm_str)
-        dm_f.close()
-        self.files_to_remove.append(self.dm_fp)
+        self.dm1_fp = join(self.test_dir, 'dm1.txt')
+        dm1_f = open(self.dm1_fp, 'w')
+        dm1_f.write(dm1_str)
+        dm1_f.close()
+        self.files_to_remove.append(self.dm1_fp)
+
+        self.dm2_fp = join(self.test_dir, 'dm2.txt')
+        dm2_f = open(self.dm2_fp, 'w')
+        dm2_f.write(dm2_str)
+        dm2_f.close()
+        self.files_to_remove.append(self.dm2_fp)
 
         self.invalid_dm_fp = join(self.test_dir, 'invalid_dm.txt')
         invalid_dm_f = open(self.invalid_dm_fp, 'w')
@@ -47,11 +53,17 @@ class CompareCategoriesTests(TestCase):
         invalid_dm_f.close()
         self.files_to_remove.append(self.invalid_dm_fp)
 
-        self.map_fp = join(self.test_dir, 'map.txt')
-        map_f = open(self.map_fp, 'w')
-        map_f.write(map_str)
-        map_f.close()
-        self.files_to_remove.append(self.map_fp)
+        self.map1_fp = join(self.test_dir, 'map1.txt')
+        map1_f = open(self.map1_fp, 'w')
+        map1_f.write(map1_str)
+        map1_f.close()
+        self.files_to_remove.append(self.map1_fp)
+
+        self.map2_fp = join(self.test_dir, 'map2.txt')
+        map2_f = open(self.map2_fp, 'w')
+        map2_f.write(map2_str)
+        map2_f.close()
+        self.files_to_remove.append(self.map2_fp)
 
         self.cat_methods = ['adonis', 'anosim', 'mrpp', 'permanova',
                             'permdisp', 'dbrda']
@@ -73,7 +85,7 @@ class CompareCategoriesTests(TestCase):
     def test_compare_categories_categorical_variables(self):
         """Test compare_categories() on categorical methods/input."""
         for method in self.cat_methods:
-            compare_categories(self.dm_fp, self.map_fp, method,
+            compare_categories(self.dm1_fp, self.map1_fp, method,
                     self.cat_categories, self.num_perms, self.test_dir)
             results_fp = join(self.test_dir, '%s_results.txt' % method)
             self.files_to_remove.append(results_fp)
@@ -87,7 +99,7 @@ class CompareCategoriesTests(TestCase):
     def test_compare_categories_numeric_variables(self):
         """Test compare_categories() on numeric methods/input."""
         for method in self.num_methods:
-            compare_categories(self.dm_fp, self.map_fp, method,
+            compare_categories(self.dm1_fp, self.map1_fp, method,
                     self.num_categories, self.num_perms, self.test_dir)
             results_fp = join(self.test_dir, '%s_results.txt' % method)
             self.files_to_remove.append(results_fp)
@@ -96,54 +108,66 @@ class CompareCategoriesTests(TestCase):
             results_f.close()
             self.assertTrue(len(results) > 0)
 
+    def test_compare_categories_morans_i_zeros(self):
+        """Test Moran's I on distance matrix with non-diagonal zeros."""
+        method = 'morans_i'
+        compare_categories(self.dm2_fp, self.map2_fp, method, ['NumCat'], 999,
+                           self.test_dir)
+        results_fp = join(self.test_dir, '%s_results.txt' % method)
+        self.files_to_remove.append(results_fp)
+        results_f = open(results_fp, 'U')
+        results = results_f.readlines()
+        results_f.close()
+        self.assertTrue(len(results) > 0)
+
     def test_compare_categories_invalid_input(self):
         """Test compare_categories() on invalid input that should error out."""
         # Non-numeric categories with BEST and Moran's I.
         for method in self.num_methods:
-            self.assertRaises(TypeError, compare_categories, self.dm_fp,
-                    self.map_fp, method, self.cat_categories, self.num_perms,
+            self.assertRaises(TypeError, compare_categories, self.dm1_fp,
+                    self.map1_fp, method, self.cat_categories, self.num_perms,
                     self.test_dir)
 
         # SampleID with all methods.
         for method in self.num_methods + self.cat_methods:
-            self.assertRaises(ValueError, compare_categories, self.dm_fp,
-                    self.map_fp, method, ['SampleID'], self.num_perms,
+            self.assertRaises(ValueError, compare_categories, self.dm1_fp,
+                    self.map1_fp, method, ['SampleID'], self.num_perms,
                     self.test_dir)
 
         # Single category passed as a string instead of a list of string(s).
         for method in self.num_methods + self.cat_methods:
-            self.assertRaises(TypeError, compare_categories, self.dm_fp,
-                    self.map_fp, method, 'SampleID', self.num_perms,
+            self.assertRaises(TypeError, compare_categories, self.dm1_fp,
+                    self.map1_fp, method, 'SampleID', self.num_perms,
                     self.test_dir)
 
         # Non-symmetric/hollow distance matrix.
         for method in self.num_methods:
             self.assertRaises(ValueError, compare_categories,
-                    self.invalid_dm_fp, self.map_fp, method,
+                    self.invalid_dm_fp, self.map1_fp, method,
                     self.num_categories, self.num_perms, self.test_dir)
         for method in self.cat_methods:
             self.assertRaises(ValueError, compare_categories,
-                    self.invalid_dm_fp, self.map_fp, method,
+                    self.invalid_dm_fp, self.map1_fp, method,
                     self.cat_categories, self.num_perms, self.test_dir)
 
         # Nonexistent category.
         for method in self.num_methods + self.cat_methods:
-            self.assertRaises(ValueError, compare_categories, self.dm_fp,
-                    self.map_fp, method, ['bar'], self.num_perms,
+            self.assertRaises(ValueError, compare_categories, self.dm1_fp,
+                    self.map1_fp, method, ['bar'], self.num_perms,
                     self.test_dir)
 
         # Unique category values only.
         for method in self.cat_methods:
-            self.assertRaises(ValueError, compare_categories, self.dm_fp,
-                    self.map_fp, method, ['Unique'], self.num_perms,
+            self.assertRaises(ValueError, compare_categories, self.dm1_fp,
+                    self.map1_fp, method, ['Unique'], self.num_perms,
                     self.test_dir)
 
         # Only a single category value.
         for method in self.cat_methods + self.num_methods:
             if method == 'best':
                 # BEST is okay with this type of category.
-                compare_categories(self.dm_fp,
-                        self.map_fp, method, ['Single'], self.num_perms,
+                compare_categories(self.dm1_fp,
+                        self.map1_fp, method, ['Single'], self.num_perms,
                         self.test_dir)
                 results_fp = join(self.test_dir, '%s_results.txt' % method)
                 self.files_to_remove.append(results_fp)
@@ -152,23 +176,23 @@ class CompareCategoriesTests(TestCase):
                 results_f.close()
                 self.assertTrue(len(results) > 0)
             else:
-                self.assertRaises(ValueError, compare_categories, self.dm_fp,
-                        self.map_fp, method, ['Single'], self.num_perms,
+                self.assertRaises(ValueError, compare_categories, self.dm1_fp,
+                        self.map1_fp, method, ['Single'], self.num_perms,
                         self.test_dir)
 
         # Bad number of permutations.
         for method in self.cat_methods:
-            self.assertRaises(ValueError, compare_categories, self.dm_fp,
-                    self.map_fp, method, self.cat_categories, -42,
+            self.assertRaises(ValueError, compare_categories, self.dm1_fp,
+                    self.map1_fp, method, self.cat_categories, -42,
                     self.test_dir)
 
         # Unrecognized method.
-        self.assertRaises(ValueError, compare_categories, self.dm_fp,
-                          self.map_fp, 'foo', self.cat_categories,
+        self.assertRaises(ValueError, compare_categories, self.dm1_fp,
+                          self.map1_fp, 'foo', self.cat_categories,
                           self.num_perms, self.test_dir)
 
 
-dm_str = """\tPC.354\tPC.355\tPC.356\tPC.481\tPC.593\tPC.607\tPC.634\tPC.635\tPC.636
+dm1_str = """\tPC.354\tPC.355\tPC.356\tPC.481\tPC.593\tPC.607\tPC.634\tPC.635\tPC.636
 PC.354\t0.0\t0.595483768391\t0.618074717633\t0.582763100909\t0.566949022108\t0.714717232268\t0.772001731764\t0.690237118413\t0.740681707488
 PC.355\t0.595483768391\t0.0\t0.581427669668\t0.613726772383\t0.65945132763\t0.745176523638\t0.733836123821\t0.720305073505\t0.680785600439
 PC.356\t0.618074717633\t0.581427669668\t0.0\t0.672149021573\t0.699416863323\t0.71405573754\t0.759178215168\t0.689701276341\t0.725100672826
@@ -178,6 +202,13 @@ PC.607\t0.714717232268\t0.745176523638\t0.71405573754\t0.666018240373\t0.7037202
 PC.634\t0.772001731764\t0.733836123821\t0.759178215168\t0.66532968784\t0.748240937349\t0.707316869557\t0.0\t0.565875193399\t0.560605525642
 PC.635\t0.690237118413\t0.720305073505\t0.689701276341\t0.650464714994\t0.73416971958\t0.636288883818\t0.565875193399\t0.0\t0.575788039321
 PC.636\t0.740681707488\t0.680785600439\t0.725100672826\t0.632524644216\t0.727154987937\t0.699880573956\t0.560605525642\t0.575788039321\t0.0
+"""
+
+# Some zeros in the matrix (not just on the diagonal).
+dm2_str = """\tS1\tS2\tS3
+S1\t0.0\t0.0\t0.5
+S2\t0.0\t0.0\t0.1
+S3\t0.5\t0.1\t0.0
 """
 
 # Non-symmetric. :(
@@ -193,7 +224,7 @@ PC.635\t0.690237118413\t0.720305073505\t0.689701276341\t0.650464714994\t0.734169
 PC.636\t0.740681707488\t0.680785600439\t0.725100672826\t0.632524644216\t0.727154987937\t0.699880573956\t0.560605525642\t0.575788039321\t0.0
 """
 
-map_str = """#SampleID\tBarcodeSequence\tLinkerPrimerSequence\tTreatment\tDOB\tUnique\tSingle\tDescription
+map1_str = """#SampleID\tBarcodeSequence\tLinkerPrimerSequence\tTreatment\tDOB\tUnique\tSingle\tDescription
 #Example mapping file for the QIIME analysis package.  These 9 samples are from a study of the effects of exercise and diet on mouse cardiac physiology (Crawford, et al, PNAS, 2009).
 PC.354\tAGCACGAGCCTA\tYATGCTGCCTCCCGTAGGAGT\tControl\t20061218\t1\t2\tControl_mouse_I.D._354
 PC.355\tAACTCGTCGATG\tYATGCTGCCTCCCGTAGGAGT\tControl\t20061218\t2\t2\tControl_mouse_I.D._355
@@ -204,6 +235,12 @@ PC.607\tAACTGTGCGTAC\tYATGCTGCCTCCCGTAGGAGT\tFast\t20071112\t6\t2\tFasting_mouse
 PC.634\tACAGAGTCGGCT\tYATGCTGCCTCCCGTAGGAGT\tFast\t20080116\t7\t2\tFasting_mouse_I.D._634
 PC.635\tACCGCAGAGTCA\tYATGCTGCCTCCCGTAGGAGT\tFast\t20080116\t8\t2\tFasting_mouse_I.D._635
 PC.636\tACGGTGAGTGTC\tYATGCTGCCTCCCGTAGGAGT\tFast\t20080116\t9\t2\tFasting_mouse_I.D._636
+"""
+
+map2_str = """#SampleID\tBarcodeSequence\tLinkerPrimerSequence\tNumCat\tDescription
+S1\tAGCACGAGCCTA\tYATGCTGCCTCCCGTAGGAGT\t2\tS1
+S2\tAACTCGTCGATG\tYATGCTGCCTCCCGTAGGAGT\t2\tS2
+S3\tACAGACCACTCA\tYATGCTGCCTCCCGTAGGAGT\t3\tS3
 """
 
 


### PR DESCRIPTION
This issue came up during the biogeo project when there are identical samples in the distance matrix, which result in zeros that aren't isolated to the diagonal. R's `Moran.I` would error out on this input.

The fix is to substitute a very small number for the zeros in the matrix (since we can't use zero itself). @antgonza, @gregcaporaso, and I discussed this in detail on the private biogeo issue tracker.

These changes also add an explicit test for this case.
