### PR TITLE
fixed suppress_submit_jobs being hard-coded to False. It now takes the v...

### DIFF
--- a/scripts/parallel_pick_otus_usearch61_ref.py
+++ b/scripts/parallel_pick_otus_usearch61_ref.py
@@ -131,7 +131,7 @@ def main():
                     params,
                     job_prefix=opts.job_prefix,
                     poll_directly=opts.poll_directly,
-                    suppress_submit_jobs=False)
+                    suppress_submit_jobs=opts.suppress_submit_jobs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`--suppress_submit_jobs` is no longer hard-coded to `False` and now takes the value of `opts.suppress_submit_jobs`
