### PR TITLE
Alpha diversity.py changes

### DIFF
--- a/scripts/alpha_diversity.py
+++ b/scripts/alpha_diversity.py
@@ -57,7 +57,7 @@ script_info['optional_options']=[\
      type='existing_path'),
  make_option('-o', '--output_path',
      help='Output filepath to store alpha diversity metric(s) for each sample in a tab-separated format' +\
-     '(or output directory when batch processing). [default: %default]',
+     'or output directory when batch processing. [default: %default]',
      type='new_path'),
  make_option('-m', '--metrics', type='multiple_choice',
      mchoices=list_known_metrics(),


### PR DESCRIPTION
Error messages now use option_parser.error instead of print statements.
If a directory is being passed as output path for a single file, leading to an IOError on line 98, the error message specifies so.
