### PR TITLE
uclust OTU picker handles filenames with multiple dots

### DIFF
--- a/qiime/parallel/pick_otus.py
+++ b/qiime/parallel/pick_otus.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 __author__ = "Greg Caporaso"
 __copyright__ = "Copyright 2011, The QIIME project"
-__credits__ = ["Greg Caporaso", "Jens Reeder"]
+__credits__ = ["Greg Caporaso", "Jens Reeder", "Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.7.0-dev"
 __maintainer__ = "Greg Caporaso"
@@ -152,7 +152,7 @@ class ParallelPickOtusUclustRef(ParallelPickOtus):
             
         if params['save_uc_files']:
             save_uc_files_str = ''
-            out_filenames += [job_prefix + '%d_clusters.uc']
+            out_filenames += [job_prefix + '.%d_clusters.uc']
         else:
             save_uc_files_str = '-d'
         

--- a/qiime/pick_otus.py
+++ b/qiime/pick_otus.py
@@ -31,11 +31,11 @@ from cogent.util.misc import remove_files
 from cogent import LoadSeqs, DNA, Alignment
 from cogent.util.trie import build_prefix_map
 from cogent.util.misc import flatten
-from cogent.app.uclust import get_clusters_from_fasta_filepath
 
 from qiime.util import FunctionWithParams, get_tmp_filename, get_qiime_temp_dir
 from qiime.sort import sort_fasta_by_abundance
 from qiime.parse import fields_to_dict
+from qiime.pycogent_backports.uclust import get_clusters_from_fasta_filepath
 from qiime.pycogent_backports.usearch import (usearch_qf,
  usearch61_denovo_cluster, usearch61_ref_cluster)
 

--- a/qiime/pycogent_backports/uclust.py
+++ b/qiime/pycogent_backports/uclust.py
@@ -12,7 +12,7 @@ Modified from cogent.app.cd_hit.py on 1-21-10, written by Daniel McDonald.
 
 __author__ = "William Walters"
 __copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["William Walters","Greg Caporaso"]
+__credits__ = ["William Walters","Greg Caporaso","Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.5.3-dev"
 __maintainer__ = "William Walters"
@@ -20,7 +20,7 @@ __email__ = "william.a.walters@colorado.edu"
 __status__ = "Production"
 
 from os import remove, makedirs
-from os.path import split, splitext, basename, isdir, abspath, isfile
+from os.path import split, splitext, basename, isdir, abspath, isfile, join
 from cogent.parse.fasta import MinimalFastaParser
 from cogent.app.parameters import ValuedParameter, FlagParameter
 from cogent.app.util import CommandLineApplication, ResultPath,\
@@ -455,21 +455,10 @@ def uclust_cluster_from_sorted_fasta_filepath(
     app_result = app({'--input':fasta_filepath,'--uc':output_filepath})
     return app_result
 
-
 def get_output_filepaths(output_dir, fasta_filepath):
     """ Returns filepaths for intermediate file to be kept """
-    
-    if not output_dir.endswith('/'):
-        output_dir += '/'
-        
-    output_file_basename = "".join(basename(fasta_filepath).split('.')[0:-1])
-    uc_save_filepath = '%s%s_clusters.uc' % \
-     (output_dir, output_file_basename)
-
-    return uc_save_filepath
-
-
-
+    return join(output_dir,
+                splitext(basename(fasta_filepath))[0] + '_clusters.uc')
 
 def get_clusters_from_fasta_filepath(
     fasta_filepath,

--- a/qiime/pycogent_backports/usearch.py
+++ b/qiime/pycogent_backports/usearch.py
@@ -27,7 +27,7 @@ from cogent.app.parameters import ValuedParameter, FlagParameter
 from cogent.app.util import CommandLineApplication, ResultPath,\
  get_tmp_filename, ApplicationError, ApplicationNotFoundError
 from cogent.util.misc import remove_files
-from cogent.app.uclust import clusters_from_uc_file
+from qiime.pycogent_backports.uclust import clusters_from_uc_file
 
 class UsearchParseError(Exception):
     pass

--- a/tests/test_pycogent_backports/test_uclust.py
+++ b/tests/test_pycogent_backports/test_uclust.py
@@ -23,7 +23,8 @@ from qiime.pycogent_backports.uclust import (Uclust,
 
 __author__ = "William Walters"
 __copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Daniel McDonald","William Walters","Greg Caporaso"]
+__credits__ = ["Daniel McDonald","William Walters","Greg Caporaso",
+               "Jai Ram Rideout"]
 __license__ = "GPL"
 __version__ = "1.5.3-dev"
 __maintainer__ = "William Walters"
@@ -296,9 +297,11 @@ class UclustConvenienceWrappers(TestCase):
         
         self.assertEqual(uc_res, "/tmp/test_seqs_clusters.uc")
 
-        
+    def test_get_output_filepaths_multiple_dots(self):
+        """Generates filepath names from names with more than one dot"""
+        obs = get_output_filepaths("/tmp", "test_seqs.filtered.fasta")
+        self.assertEqual(obs, "/tmp/test_seqs.filtered_clusters.uc")
 
-        
     def test_get_clusters_from_fasta_filepath(self):
         """ Tests for return of lists of OTUs from given fasta filepath """
         


### PR DESCRIPTION
Intermediate .uc files are now correctly named based on the input sequences filename, including the case where there are multiple dots in the filename.

Also updated QIIME codebase to use uclust.py in pycogent_backports/ (was previously only being used in assign_taxonomy.py).

Fixes #191.
