### PR TITLE
updated to use QIIME's temp_dir

### DIFF
--- a/qiime/align_seqs.py
+++ b/qiime/align_seqs.py
@@ -32,7 +32,9 @@ from cogent.parse.rfam import MinimalRfamParser, ChangedSequence
 import cogent.app.clustalw
 import cogent.app.mafft
 
-from qiime.util import get_tmp_filename, FunctionWithParams
+from qiime.util import (get_tmp_filename,
+                        FunctionWithParams,
+                        get_qiime_temp_dir)
 import cogent.app.muscle_v38
 
 
@@ -256,7 +258,8 @@ class PyNastAligner(Aligner):
             min_pct=self.Params['min_pct'],
             min_len=self.Params['min_len'],
             align_unaligned_seqs_f=pairwise_alignment_f,
-            logger=logger)
+            logger=logger,
+            temp_dir=get_qiime_temp_dir())
 
         logger.record(str(self))
 

--- a/qiime/parallel/align_seqs.py
+++ b/qiime/parallel/align_seqs.py
@@ -14,6 +14,7 @@ __status__ = "Development"
 from cogent.app.formatdb import build_blast_db_from_fasta_path
 from qiime.align_seqs import compute_min_alignment_length
 from qiime.parallel.util import ParallelWrapper
+from qiime.util import get_qiime_temp_dir
 
 class ParallelAlignSeqsPyNast(ParallelWrapper):
     _script_name = "align_seqs.py"
@@ -25,7 +26,8 @@ class ParallelAlignSeqsPyNast(ParallelWrapper):
             # Build the blast database from the reference_seqs_fp -- all procs
             # will then access one db rather than create one per proc
             blast_db, db_files_to_remove = \
-                 build_blast_db_from_fasta_path(params['template_fp'])
+             build_blast_db_from_fasta_path(params['template_fp'],
+                                            output_dir=get_qiime_temp_dir())
             self.files_to_remove += db_files_to_remove
             params['blast_db'] = blast_db
         


### PR DESCRIPTION
There were two places where QIIME's `temp_dir` wasn't being used:
1. When building the BLAST DB to search against. This is fixed by this pull request. 
2. When calling `pynast.util.pynast_seqs`. This is partially fixed by this pull request, but also requires PyNAST 1.2.1 or later to actually work (the PyNAST release will be published within the next few days). If using PyNAST 1.2.0, QIIME's `temp_dir` will be passed to `pynast_seqs`, though not actually used (`pynast_seqs` takes `**kwargs`, so the parameter can be passed but is just ignored). PyNAST 1.2.1 has been updated to actually use that value. 

This fixes #1114. 
