### PR TITLE
Remove "versions" from the QIIME overview tutorial

### DIFF
--- a/doc/tutorials/tutorial.rst
+++ b/doc/tutorials/tutorial.rst
@@ -14,7 +14,7 @@ In this walkthrough, text like the following: ::
 
     print_qiime_config.py
 
-denotes the command-line invocation of scripts. You can find full usage information for each script by passing the -h option (help) and/or by reading the full description in the `Documentation <../documentation/index.html>`_. Execute all tutorial commands from within the :file:`qiime_tutorial` directory, which can be downloaded from here: `QIIME Tutorial files <ftp://thebeast.colorado.edu/pub/qiime-files/qiime_tutorial.zip>`_.
+denotes the command-line invocation of scripts. You can find full usage information for each script by passing the -h option (help) and/or by reading the full description in the `Documentation <../documentation/index.html>`_. Execute all tutorial commands from within the :file:`qiime_overview_tutorial` directory, which can be downloaded from here: `QIIME Overview Tutorial files <ftp://thebeast.colorado.edu/pub/qiime-files/qiime_overview_tutorial.zip>`_.
 
 To process our data, we will perform the following analyses, each of which is described in more detail below:
 
@@ -28,7 +28,7 @@ To process our data, we will perform the following analyses, each of which is de
 
 Essential Files
 ----------------
-All the files you will need for this tutorial are here (ftp://thebeast.colorado.edu/pub/qiime-files/qiime_tutorial.zip). Descriptions of these files are below.
+All the files you will need for this tutorial are here (ftp://thebeast.colorado.edu/pub/qiime-files/qiime_overview_tutorial.zip). Descriptions of these files are below.
 
 Sequences (.fna)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The document was pointing to an FTP site that read "QIIME-1.5.0" and in
turn was confusing users. I've changed this such that there's now a
folder named qiime-files in thebeast.colorado.edu where I've copied the
current contents of qiime/examples/qiime_tutorial/ and updated the
documentation of tutorial.rst.

Fixes #1137
