### PR TITLE
incomplete sentences, timings, removed gg download

### DIFF
--- a/examples/ipynb/illumina_overview_tutorial.ipynb
+++ b/examples/ipynb/illumina_overview_tutorial.ipynb
@@ -26,9 +26,7 @@
      "source": [
       "## Getting started\n",
       "\n",
-      "We'll begin by downloading data and initializing some variables to configure our IPython computing environment.\n",
-      "\n",
-      "Note: If you are using an Apple computer, we recommend downloading the dataset directly using the above link as OS X does not come with ``wget`` pre-installed. Alternatively, ``wget`` can be compiled from [source](ftp://ftp.gnu.org/gnu/wget/) or you can use ``curl``, which is similar to ``wget`` although the usage is different."
+      "We'll begin by downloading data and initializing some variables to configure our IPython computing environment.\n"
      ]
     },
     {
@@ -48,7 +46,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "!wget https://s3.amazonaws.com/s3-qiime_tutorial_files/moving_pictures_tutorial-1.8.0.tgz\n",
+      "!(wget https://s3.amazonaws.com/s3-qiime_tutorial_files/moving_pictures_tutorial-1.8.0.tgz || curl -O https://s3.amazonaws.com/s3-qiime_tutorial_files/moving_pictures_tutorial-1.8.0.tgz)\n",
       "!tar -xzf moving_pictures_tutorial-1.8.0.tgz"
      ],
      "language": "python",


### PR DESCRIPTION
Fixed some issues, making the call to `validate_mapping_file.py`, added a approx. timing mention to `pick_open_reference_otus.py` and most notably removed the download for greengenes. The untar'ing on EC2 instances is brutal, and these data should be staged anyway in the instance (though not sure if this is the case with the QIIME AMIs)
