### PR TITLE
print_qiime_config.py mpl version check handles rc

### DIFF
--- a/scripts/print_qiime_config.py
+++ b/scripts/print_qiime_config.py
@@ -292,7 +292,10 @@ class QIIMEDependencyBase(QIIMEConfig):
         max_acceptable_version = (1, 3, 1)
         try:
             from matplotlib import __version__ as matplotlib_lib_version
-            version = tuple(map(int, matplotlib_lib_version.split('.')))
+            version = matplotlib_lib_version.split('.')
+            if version[-1].endswith('rc'):
+                version[-1] = version[-1][:-2]
+            version = tuple(map(int, version))
             pass_test = (version >= min_acceptable_version and
                          version <= max_acceptable_version)
             version_string = str(matplotlib_lib_version)


### PR DESCRIPTION
The version check for matplotlib that is performed in print_qiime_config.py now handles version strings that end in `rc`. For example, `1.1.1rc` now passes the version check instead of throwing a `ValueError` when casting the last element to an integer.

Ran into this issue when testing out a QIIME installation that had mpl 1.1.1rc installed.
