### PR TITLE
Remove usage of cogent.util.misc.flatten

### DIFF
--- a/qiime/make_3d_plots.py
+++ b/qiime/make_3d_plots.py
@@ -20,7 +20,6 @@ from time import strftime
 from numpy.linalg import norm
 from biplots import make_mage_taxa
 from numpy import abs as numpy_abs
-from cogent.util.misc import flatten
 from qiime.format import format_coords
 from cogent.maths.stats.util import Numbers
 from qiime.sort import natsort, signed_natsort
@@ -241,7 +240,8 @@ def make_mage_output(groups, colors, coord_header, coords, pct_var,
     # check that we didn't get fewer dimensions than we wanted
     if len(mins) < num_coords:
         num_coords = len(mins)
-    min_maxes = flatten(zip(mins, maxes))
+    # flatten out the tuples
+    min_maxes = sum(zip(mins, maxes), ())
 
     if custom_axes:
         axis_names = ['PC%s' % (i + 1)

--- a/qiime/make_otu_table.py
+++ b/qiime/make_otu_table.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from string import strip
 from sys import stderr
 from numpy import array, zeros
-from cogent.util.misc import flatten, InverseDict
+from cogent.util.misc import InverseDict
 from qiime.format import format_otu_table
 from qiime.parse import parse_otu_map
 from qiime.format import format_biom_table
@@ -34,7 +34,8 @@ def libs_from_seqids(seq_ids, delim='_'):
 
 def seqids_from_otu_to_seqid(otu_to_seqid):
     """Returns set of all seq ids from libs"""
-    return set(flatten(otu_to_seqid.values()))
+    # flatten out the list of lists
+    return set(sum(otu_to_seqid.values(), []))
 
 
 def make_otu_table(otu_map_f,

--- a/qiime/pick_otus.py
+++ b/qiime/pick_otus.py
@@ -31,7 +31,6 @@ from cogent.core.sequence import DnaSequence
 from cogent.util.misc import remove_files
 from cogent import LoadSeqs, DNA, Alignment
 from cogent.util.trie import build_prefix_map
-from cogent.util.misc import flatten
 
 from qiime.util import FunctionWithParams, get_tmp_filename, get_qiime_temp_dir
 from qiime.sort import sort_fasta_by_abundance
@@ -1704,8 +1703,9 @@ class MothurOtuPicker(OtuPicker):
 
 def expand_otu_map_seq_ids(otu_map, seq_id_map):
     for otu_id, seq_ids in otu_map.items():
-        mapped_seq_ids = flatten(
-            [seq_id_map[seq_id] for seq_id in seq_ids])
+        # flatten out the list of lists
+        mapped_seq_ids = sum(
+            [seq_id_map[seq_id] for seq_id in seq_ids], [])
         otu_map[otu_id] = mapped_seq_ids
     return otu_map
 


### PR DESCRIPTION
All of these now use `sum([['foo', 'bar'], ['baz']], [])` or it's tuple
equivalent.
