### PR TITLE
BUG: Pass file path to convert_biom_to_table

### DIFF
--- a/qiime/supervised_learning.py
+++ b/qiime/supervised_learning.py
@@ -177,7 +177,7 @@ class RSupervisedLearner(CommandLineApplication):
         temp_predictor_fp = join(self.Parameters['-o'].Value,
                                  splitext(split(data)[1])[0] + '.txt')
         temp_predictor_f = open(temp_predictor_fp, 'w')
-        temp_predictor_f.write(convert_biom_to_table(open(data, 'U')))
+        temp_predictor_f.write(convert_biom_to_table(data))
         temp_predictor_f.close()
         predictor_fp = temp_predictor_fp
 


### PR DESCRIPTION
This function did not deal well with file like objects now that HDF5 is a
supported format, internally changing convert_biom_to_table to use 
biom.load_table fixes this problem.

Fix #1598
