### PR TITLE
BUG: Fix #1608

### DIFF
--- a/qiime/split.py
+++ b/qiime/split.py
@@ -18,6 +18,11 @@ from qiime.format import format_mapping_file
 from biom.table import TableException
 
 
+class OTUTableSplitError(ValueError):
+    """Exception raised when an OTU table cannot be split"""
+    pass
+
+
 def get_mapping_values(mapping_f, mapping_field):
     mapping_data, mapping_headers, comments = parse_mapping_file(mapping_f)
 
@@ -91,9 +96,9 @@ def split_otu_table_on_sample_metadata(otu_table, mapping_f, mapping_field):
         yield v_fp_str, filtered_otu_table
 
     if not tables:
-        raise ValueError("Could not split OTU tables! There are no matches "
-                         "between the sample identifiers in the OTU table and "
-                         "in the mapping file.")
+        raise OTUTableSplitError("Could not split OTU tables! There are no "
+                                 "matches between the sample identifiers in "
+                                 "the OTU table and the mapping file.")
 
 
 def split_fasta(infile, seqs_per_file, outfile_prefix, working_dir=''):

--- a/scripts/split_otu_table.py
+++ b/scripts/split_otu_table.py
@@ -20,7 +20,8 @@ from qiime.util import (parse_command_line_parameters, make_option, create_dir,
                         write_biom_table)
 from qiime.parse import parse_mapping_file
 from qiime.split import (split_mapping_file_on_field,
-                         split_otu_table_on_sample_metadata)
+                         split_otu_table_on_sample_metadata,
+                         OTUTableSplitError)
 
 script_info = {}
 script_info[
@@ -100,7 +101,7 @@ def main():
                 otu_table_base_name, fp_str))
 
             write_biom_table(sub_otu_table_s, otu_table_output_fp)
-    except ValueError as e:
+    except OTUTableSplitError as e:
         option_parser.error(e)
 
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -22,7 +22,7 @@ from skbio.parse.sequences import parse_fasta
 
 from qiime.split import (split_mapping_file_on_field,
                          split_otu_table_on_sample_metadata,
-                         split_fasta)
+                         split_fasta, OTUTableSplitError)
 from qiime.util import get_qiime_temp_dir, remove_files
 
 
@@ -67,7 +67,7 @@ class SplitTests(TestCase):
     def test_split_otu_table_on_sample_metadata_exceptions(self):
 
         # mapping file 3 has no sample identifiers matching the OTU table
-        with self.assertRaises(ValueError):
+        with self.assertRaises(OTUTableSplitError):
             a = list(split_otu_table_on_sample_metadata(self.otu_table_f1,
                                                         self.mapping_f3,
                                                         "Treatment"))


### PR DESCRIPTION
split_otu_table.py would produce a directory with only mapping files and no
OTU tables, this was happening because the axis in the filter operation was
`'observation'` instead of `'sample'`.
