### PR TITLE
BUG/DOC: Remove reference to make_emperor.py

### DIFF
--- a/scripts/add_alpha_to_mapping_file.py
+++ b/scripts/add_alpha_to_mapping_file.py
@@ -21,7 +21,7 @@ script_info = {}
 script_info['brief_description'] = "Add alpha diversity data to a metadata " +\
     "mapping file"
 script_info['script_description'] = "Add alpha diversity data to a mapping " +\
-    "file for use with other QIIME scripts, i. e. make_emperor.py. The " +\
+    "file for use with other QIIME scripts, i. e. make_emperor. The " +\
     "resulting mapping file will contain three new columns per metric in the " +\
     "alpha diversity data; the first column being the raw value, the second " +\
     "being a normalized raw value and the third one a label classifying " +\


### PR DESCRIPTION
If the script name is written as make_emperor.py, the autogenerated 
documentation will create a dead link as there's no script named 
make_emperor.py in QIIME.

Removing the extension fixes this problem.
