### PR TITLE
Create paired_barcodes

### DIFF
--- a/paired_barcodes
+++ b/paired_barcodes
@@ -1,0 +1,1 @@
+Add support using paired sequencing with a combination of both 5' and 3' barcode.


### PR DESCRIPTION
add support to integrate the analysis from paired-end sequencing with both 5' and 3' barcodes.
