### PR TITLE
TST/REVERT: reduction of the runtime of the test

### DIFF
--- a/tests/test_workflow/test_core_diversity_analyses.py
+++ b/tests/test_workflow/test_core_diversity_analyses.py
@@ -145,8 +145,9 @@ class CoreDiversityAnalysesTests(TestCase):
             20,
             output_dir=self.test_out,
             params=parse_qiime_parameters({}),
+            arare_num_steps=3,
             qiime_config=self.qiime_config,
-            categories=['SampleType'],
+            categories=['SampleType', 'days_since_epoch'],
             tree_fp=self.test_data['tree'][0],
             parallel=True,
             status_update_callback=no_status_updates)
@@ -158,7 +159,7 @@ class CoreDiversityAnalysesTests(TestCase):
             '%s/taxa_plots' % self.test_out,
             '%s/bdiv_even20/unweighted_unifrac_dm.txt' % self.test_out,
             '%s/bdiv_even20/weighted_unifrac_pc.txt' % self.test_out,
-            '%s/arare_max20/compare_chao1/SampleType_stats.txt' % self.test_out,
+            '%s/arare_max20/compare_chao1/days_since_epoch_stats.txt' % self.test_out,
             '%s/arare_max20/compare_PD_whole_tree/SampleType_boxplots.pdf' % self.test_out,
             '%s/index.html' % self.test_out,
             '%s/table_mc%d.biom.gz' % (self.test_out, 20)


### PR DESCRIPTION
... plus reversion of misguided attempt at doing that yesterday.

Specifically, the changes are:
- reduce the number of steps between min and max to take during alpha rarefaction
- perform categorical analyses on two categories instead of one (I changed to one yesterday, but the effect on run time is so small that we may as well just keep it as it was)

This _should_ allow the test to complete within the timeout period, but doesn't fix the performance issue noted in #1710.
