### PR TITLE
MAINT: Update emperor requirement

### DIFF
--- a/doc/install/install.rst
+++ b/doc/install/install.rst
@@ -87,9 +87,9 @@ The next are python packages not included in Canopy Express. Each of these can b
 * biom-format 1.3.1 (`src_biom <https://pypi.python.org/packages/source/b/biom-format/biom-format-1.3.1.tar.gz>`_) (license: BSD)
 * qcli 0.1.0 (`src_qcli <https://pypi.python.org/packages/source/q/qcli/qcli-0.1.0.tar.gz>`_) (license: GPL)
 * PyNAST 1.2.2 (`src_pynast <https://pypi.python.org/packages/source/p/pynast/pynast-1.2.2.tar.gz>`_) (license: BSD)
-* Emperor 0.9.3 (`src_emperor <https://pypi.python.org/packages/source/e/emperor/emperor-0.9.3.tar.gz>`_) (license: BSD)
+* Emperor >= 0.9.5 and < 1.0.0 (`src_emperor <https://pypi.python.org/packages/source/e/emperor/emperor-0.9.5.tar.gz>`_) (license: BSD)
 * pyqi 0.3.1 (`src_pyqi <https://pypi.python.org/packages/source/p/pyqi/pyqi-0.3.1.tar.gz>`_) (license: BSD)
-* scikit-bio 0.1.1-dev (latest development version) (`src_skbio <https://github.com/biocore/scikit-bio>`_) (license: BSD)
+* scikit-bio 0.2.1 (`src_skbio https://pypi.python.org/packages/source/s/scikit-bio/scikit-bio-0.2.1.tar.gz`_) (license: BSD)
 * burrito-fillings (latest development version) (`src_bfillings <https://github.com/biocore/burrito-fillings>`_) (license: GPL)
 
 Next, there are two non-python dependencies required for the QIIME base package. These should be installed by following their respective install instructions.

--- a/setup.py
+++ b/setup.py
@@ -258,13 +258,10 @@ setup(name='qiime',
       install_requires=['numpy >= 1.7.1',
                         'matplotlib >= 1.1.0, <= 1.3.1',
                         'pynast == 1.2.2', 'qcli', 'gdata',
-                        'biom-format == 2.1', 'emperor == 0.9.4-dev',
+                        'biom-format == 2.1', 'emperor >= 0.9.5, < 1.0.0',
                         'scikit-bio == 0.2.1', 'future', 'six', 'h5py>=2.2.0',
                         'burrito-fillings >= 0.1.0, < 0.2.0',
                         'pandas >= 0.13.1', 'burrito'],
-      dependency_links=[
-        'https://github.com/biocore/emperor/archive/master.zip#egg=emperor-0.9.4-dev'
-      ],
       extras_require={'all': ['ipython[all]', 'sphinx >= 0.3']}
       )
 


### PR DESCRIPTION
Previously was pointing to 0.9.3 and 0.9.4-dev, now states it needs a version
greater than 0.9.5 and lesser than 1.0.0.

I also updated a link for scikit-bio.

Related to #1716
