### PR TITLE
BUG: do not check for comments within the metadata

### DIFF
--- a/qiime/support_files/R/loaddata.r
+++ b/qiime/support_files/R/loaddata.r
@@ -11,7 +11,7 @@
                     nlines=1,quiet=TRUE)
     close(f)
     # read the rest of the table
-    datatable <- read.table(filepath,sep='\t',skip=header.index, comment='#',quote='"',
+    datatable <- read.table(filepath,sep='\t',skip=header.index, comment='',quote='"',
                         head=F,row.names=1,check=FALSE,strip.white=TRUE)
     
     # set column names using header


### PR DESCRIPTION
@danknights, can you review this please? The issue is that it is metadata values of `foo #stuff` are treated as comments, which breaks parsing. I don't see a way to enforce that this only treats lines that _start_ with `#` as comments, but would prefer to do that if you know how.
