### PR TITLE
ERR: Error message for beta_significance.py now includes relative abundance

### DIFF
--- a/scripts/beta_significance.py
+++ b/scripts/beta_significance.py
@@ -109,9 +109,20 @@ def main():
         of.write('\n'.join(result))
         of.close()
         envs_in = open(output_fp, 'U')
+        try:
+            result = fast_unifrac_permutations_file(tree_in, envs_in,
+                                                    weighted=False,
+                                                    num_iters=opts.num_iters,
+                                                    verbose=opts.verbose,
+                                                    test_on=type_of_test)
+        except ValueError as e:
+            if e.message == ("No valid samples/environments found. Check"
+                             " whether tree tips match otus/taxa present in"
+                             " samples/environments"):
+                raise ValueError(e.message + " and that the otu abundance is"
+                                 " not relative.")
+            raise e
 
-        result = fast_unifrac_permutations_file(tree_in, envs_in,
-                                                weighted=False, num_iters=opts.num_iters, verbose=opts.verbose, test_on=type_of_test)
         envs_in.close()
         os.remove(output_fp)
 


### PR DESCRIPTION
This is ugly, but there weren't any good alternatives as ValueErrors are raised throughout `pycogent/fast_unifrac.py`.

fixes #1355 
