### PR TITLE
BUG: Fix bug in make_otu_heatmap

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -58,6 +58,7 @@ optionally a mapping file. Check out the new documentation for the naming conven
 * ``cluster_jobs_fp`` in the QIIME config file now defaults to ``start_parallel_jobs.py``. ``seconds_to_sleep`` now defaults to 1.
 * Added ``--suppress_taxonomy_assignment`` option to ``pick_closed_reference_otus.py``.
 * sumaclust v1.0.00, swarm 1.2.19, and sortmerna 2.0 are now optional dependencies (see the [QIIME install docs](http://qiime.org/install/install.html) for details).
+* Fixed bug where ``make_otu_heatmap.py`` would not respect sample order (see [#1790](https://github.com/biocore/qiime/issues/1790)).
 * Removed ``submit_to_mgrast.py`` script (see [#1780](https://github.com/biocore/qiime/issues/1780)).
 * ``qiime/workflow/pick_open_reference_otus.py`` no longer copies the permission bits of the reference file which caused a file permission failure in some cases.
 

--- a/scripts/make_otu_heatmap.py
+++ b/scripts/make_otu_heatmap.py
@@ -238,15 +238,14 @@ def main():
     # otu_order and sample_order should be ids, rather than indices
     #  to use in sortObservationOrder/sortSampleOrder
     otu_id_order = [otu_table.ids(axis='observation')[i] for i in otu_order]
-    sample_id_order = [otu_table.ids()[i] for i in sample_order]
 
     # Re-order otu table, sampleids, etc. as necessary
     otu_table = otu_table.sort_order(otu_id_order, axis='observation')
     # otu_ids not used after: tagged for deletion
     otu_ids = np.array(otu_table.ids(axis='observation'))[otu_order]
     otu_labels = np.array(otu_labels)[otu_order]
-    otu_table = otu_table.sort_order(sample_id_order)
     sample_ids = np.array(otu_table.ids())[sample_order]
+    otu_table = otu_table.sort_order(sample_ids)
 
     plot_heatmap(otu_table, otu_labels, sample_ids, opts.output_fp,
                  imagetype=opts.imagetype, width=opts.width,


### PR DESCRIPTION
The order of the sample ids was being respected by make_otu_heatmap.py and
regardless of what options were used, the sample labels remained the same.

@adamrp, @jairideout if you guys can review this, that would be amazing.        

Fixes #1790
