### PR TITLE
updates to filter_alignment.py

### DIFF
--- a/qiime/filter_alignment.py
+++ b/qiime/filter_alignment.py
@@ -8,6 +8,7 @@ from os import mkdir, remove
 from collections import defaultdict
 from itertools import izip
 
+import numpy as np
 from numpy import (nonzero, array, fromstring, repeat, bitwise_or,
     uint8, zeros, arange, finfo, mean, std)
 
@@ -38,95 +39,47 @@ def get_masked_string(s, p):
     return (fromstring(s, dtype=uint8))[p].tostring()
 
 
-def find_gaps(s, gapcode=45):
-    """Returns index array indicating locations of gaps ('-') in string s
-    """
-    return nonzero(fromstring(s, dtype=uint8) == gapcode)
-
-
-def apply_lane_mask(fastalines, lane_mask, verbose=False):
-    """ Applies lanemask to fasta-formatted data, yielding filtered seqs.
-    """
-    return apply_lane_mask_and_gap_filter(fastalines, lane_mask,
-                                          allowed_gap_frac=1, verbose=False)
-
-
-def apply_gap_filter(fastalines, allowed_gap_frac=1 - finfo(float).eps,
-                     verbose=False):
-    """ Applies gap filter to fasta-formatted data, yielding filtered seqs.
-    """
-    return apply_lane_mask_and_gap_filter(fastalines, None,
-                                          allowed_gap_frac=allowed_gap_frac, verbose=False)
-
-
-def attempt_file_reset(f):
-    """Attempt to seek 0"""
-    if hasattr(f, 'seek'):
-        f.seek(0)
-
-
 def apply_lane_mask_and_gap_filter(fastalines, mask,
                                    allowed_gap_frac=1 - finfo(float).eps,
-                                   verbose=False, entropy_threshold=None):
+                                   entropy_threshold=None):
     """Applies a mask and gap filter to fasta file, yielding filtered seqs."""
-    if entropy_threshold is not None and not (0 < entropy_threshold < 1):
-        raise ValueError('Entropy threshold parameter (-e) needs to be '
-                         'between 0 and 1')
 
-    if mask is not None:
-        mask = mask_to_positions(mask)
-        prefilter_f = lambda x: get_masked_string(x, mask)
-    else:
-        prefilter_f = lambda x: x
+    # load the alignment
+    aln = Alignment.from_fasta_records(parse_fasta(fastalines), DNA)
 
-    # resolve the gaps based on masked sequence
-    gapcounts = None
-    gapmask = slice(None)
-    if allowed_gap_frac < 1:
-        seq_count = 0.0
-        for seq_id, seq in parse_fasta(fastalines):
-            seq_count += 1
-            seq = seq.replace('.', '-')
-
-            seq = prefilter_f(seq)
-
-            if gapcounts is None:
-                gapcounts = zeros(len(seq))
-
-            gapcounts[find_gaps(seq)] += 1
-
-        gapmask = (gapcounts / seq_count) <= allowed_gap_frac
-        gapmask = mask_to_positions(gapmask)
-        attempt_file_reset(fastalines)
-
-    # resolve the entropy mask
-    if entropy_threshold is not None:
-        ent_mask = generate_lane_mask(fastalines, entropy_threshold, gapmask)
-        ent_mask = mask_to_positions(ent_mask)
-        entropy_filter_f = lambda x: get_masked_string(x, ent_mask)
-        attempt_file_reset(fastalines)
-    else:
-        entropy_filter_f = prefilter_f
-
-    # mask, degap, and yield
-    for seq_id, seq in parse_fasta(fastalines):
-        seq = seq.replace('.', '-')
-
-        # The order in which the mask is applied depends on whether a mask is
-        # specified or inferred. Specifically, if a precomputed mask is
-        # provided (e.g., the Lane mask) then it must be applied prior to a
-        # gap filter, whereas if a mask is inferred then it must be applied
-        # after a gap filter.
-        if mask is None:
-            seq = get_masked_string(seq, gapmask)
-            seq = entropy_filter_f(seq)
+    # build the entropy mask
+    if mask is None and entropy_threshold is None:
+        entropy_mask = None
+    elif mask is not None and entropy_threshold is not None:
+        raise ValueError('only mask or entropy threshold can be provided.')
+    elif mask is not None:
+        # a pre-computed mask (e.g., Lane mask) was provided
+        entropy_mask = mask_to_positions(mask)
+    elif entropy_threshold is not None:
+        if not (0 <= entropy_threshold <= 1):
+            raise ValueError('Entropy threshold parameter (-e) needs to be '
+                              'between 0 and 1')
         else:
-            seq = entropy_filter_f(seq)
-            seq = get_masked_string(seq, gapmask)
+            entropy_mask = generate_lane_mask(aln, entropy_threshold)
+            entropy_mask = mask_to_positions(entropy_mask)
+    else:
+        # it shouldn't be possible to get here
+        raise ValueError("Can't resolve parameters for "
+                         "apply_lane_mask_and_gap_filter.")
 
-        yield ">%s\n" % seq_id
+    # if entropy filtering is being applied, filter the highly entropic
+    # positions
+    if entropy_mask is not None:
+        aln = aln.subalignment(positions_to_keep=entropy_mask)
+
+    # if positional gap filtering is being applied, filter highly gapped
+    # positions
+    if allowed_gap_frac < 1:
+        aln = aln.omit_gap_positions(allowed_gap_frac)
+
+    for seq in aln:
+        yield ">%s\n" % seq.id
         yield "%s\n" % seq
-
 
 def remove_outliers(seqs, num_stds, fraction_seqs_for_stats=.95):
     """ remove sequences very different from the majority consensus
@@ -164,35 +117,29 @@ def remove_outliers(seqs, num_stds, fraction_seqs_for_stats=.95):
     return filtered_aln
 
 
-def generate_lane_mask(infile, entropy_threshold, existing_mask=None):
+def generate_lane_mask(aln, entropy_threshold):
     """ Generates lane mask dynamically by calculating base frequencies
 
-    infile: open file object for aligned fasta file
+    aln: skbio.Alignment object
     entropy_threshold:  float value that designates the percentage of entropic
      positions to be removed, i.e., 0.10 means the 10% most entropic positions
      are removed.
 
     """
-    aln = Alignment.from_fasta_records(parse_fasta(infile), DNA)
-    uncertainty = aln.position_entropies(nan_on_non_standard_chars=False)
+    if entropy_threshold == 0.0:
+        # special case: keep all positions if filtering the 0% most entropic
+        # positions
+        result = ["1"] * aln.sequence_length()
+    else:
+        entropies = aln.position_entropies(nan_on_non_standard_chars=False)
+        entropy_cutoff = np.percentile(entropies,
+                                       (1 - entropy_threshold) *100.,
+                                       interpolation='nearest')
+        result = []
+        for entropy in entropies:
+            if entropy >= entropy_cutoff:
+                result.append("0")
+            else:
+                result.append("1")
 
-    uncertainty_sorted = sorted(uncertainty)
-
-    cutoff_index = int(round((len(uncertainty_sorted) - 1) *
-                             (1 - entropy_threshold)))
-
-    max_uncertainty = uncertainty_sorted[cutoff_index]
-
-    # This correction is for small datasets with a small possible number of
-    # uncertainty values.
-    highest_certainty = min(uncertainty_sorted)
-
-    lane_mask = ""
-
-    for base in uncertainty:
-        if base >= max_uncertainty and base != highest_certainty:
-            lane_mask += "0"
-        else:
-            lane_mask += "1"
-
-    return lane_mask
+    return "".join(result)

--- a/qiime/filter_alignment.py
+++ b/qiime/filter_alignment.py
@@ -67,13 +67,12 @@ def apply_lane_mask_and_gap_filter(fastalines, mask,
         # a mask is being computed on the fly to filter the entropy_threshold
         # most entropic positions. if highly gapped positions are being omitted
         # those are filtered first, so the entropy scores for those positions
-        # aren't included when determining the entropy threshold (since they'd
+        # aren't included when determining the entropy threshold (since the
         # positions that are mostly gaps will be counted as a lot of low
         # entropy positions)
         if not (0 <= entropy_threshold <= 1):
-            raise ValueError('Entropy threshold parameter (-e) needs to be '
-                              'between 0 and 1')
-
+            raise ValueError('entropy_threshold needs to be between 0 and 1'
+                             ' (inclusive)')
         if allowed_gap_frac < 1:
             aln = aln.omit_gap_positions(allowed_gap_frac)
         entropy_mask = generate_lane_mask(aln, entropy_threshold)

--- a/qiime/filter_alignment.py
+++ b/qiime/filter_alignment.py
@@ -77,6 +77,9 @@ def apply_lane_mask_and_gap_filter(fastalines, mask,
     if allowed_gap_frac < 1:
         aln = aln.omit_gap_positions(allowed_gap_frac)
 
+    if aln.sequence_length() == 0:
+        raise ValueError("Positional filtering resulted in removal of all "
+                         "alignment positions.")
     for seq in aln:
         yield ">%s\n" % seq.id
         yield "%s\n" % seq

--- a/qiime/filter_alignment.py
+++ b/qiime/filter_alignment.py
@@ -47,11 +47,6 @@ def apply_lane_mask_and_gap_filter(fastalines, mask,
     # load the alignment
     aln = Alignment.from_fasta_records(parse_fasta(fastalines), DNA)
 
-    # if positional gap filtering is being applied, filter highly gapped
-    # positions
-    if allowed_gap_frac < 1:
-        aln = aln.omit_gap_positions(allowed_gap_frac)
-
     # build the entropy mask
     if mask is None and entropy_threshold is None:
         if allowed_gap_frac < 1:

--- a/qiime/filter_alignment.py
+++ b/qiime/filter_alignment.py
@@ -40,7 +40,7 @@ def get_masked_string(s, p):
 
 
 def apply_lane_mask_and_gap_filter(fastalines, mask,
-                                   allowed_gap_frac=1 - finfo(float).eps,
+                                   allowed_gap_frac=1.-1e-6,
                                    entropy_threshold=None):
     """Applies a mask and gap filter to fasta file, yielding filtered seqs."""
 

--- a/scripts/filter_alignment.py
+++ b/scripts/filter_alignment.py
@@ -18,9 +18,9 @@ import numpy as np
 from qiime_default_reference import get_template_alignment_column_mask
 
 from qiime.util import (load_qiime_config, parse_command_line_parameters,
-                        make_option)
+                         make_option)
 from qiime.filter_alignment import (apply_lane_mask_and_gap_filter,
-                                    remove_outliers, generate_lane_mask)
+                                     remove_outliers, generate_lane_mask)
 
 script_info = {}
 script_info[
@@ -29,12 +29,17 @@ script_info[
     'script_description'] = """This script should be applied to generate a useful tree when aligning against a template alignment (e.g., with PyNAST). This script will remove positions which are gaps in every sequence (common for PyNAST, as typical sequences cover only 200-400 bases, and they are being aligned against the full 16S gene). Additionally, the user can supply a lanemask file, that defines which positions should included when building the tree, and which should be ignored. Typically, this will differentiate between non-conserved positions, which are uninformative for tree building, and conserved positions which are informative for tree building. FILTERING ALIGNMENTS WHICH WERE BUILT WITH PYNAST AGAINST THE GREENGENES CORE SET ALIGNMENT SHOULD BE CONSIDERED AN ESSENTIAL STEP."""
 script_info['script_usage'] = []
 script_info['script_usage'].append(
-    ("""Examples:""",
+    ("""Example 1:""",
      """As a simple example of this script, the user can use the following command, which consists of an input FASTA file (i.e. resulting file from align_seqs.py) and the output directory "filtered_alignment/":""",
      """%prog -i seqs_rep_set_aligned.fasta -o filtered_alignment/"""))
 
 script_info['script_usage'].append(
-    ("",
+     ("""Example 2:""",
+     """Apply the same filtering as above, but additionally remove sequences whose distance from the majority consensus sequence is more than 3 (can be changed by passing --threshold) standard deviations above the mean:""",
+     """%prog -i seqs_rep_set_aligned.fasta -o filtered_alignment/ --remove_outliers"""))
+
+script_info['script_usage'].append(
+    ("""Example 3:""",
      """Alternatively, if the user would like to use a different gap fraction threshold ("-g"), they can use the following command:""",
      """%prog -i seqs_rep_set_aligned.fasta -o filtered_alignment/ -g 0.95"""))
 
@@ -71,7 +76,7 @@ script_info['optional_options'] = [
                 default=False),
     make_option('-t', '--threshold', action='store',
                 type='float', help='with -r, remove seqs whose dissimilarity to the ' +
-                'consensus sequence is approximately > x standard devaitions above ' +
+                'consensus sequence is approximately > x standard deviations above ' +
                 'the mean of the sequences [default: %default]',
                 default=3.0),
     make_option('-e', '--entropy_threshold', action='store',
@@ -127,18 +132,18 @@ def main():
         # apply the lanemask/gap removal, then remove outliers
 
         seq_gen = apply_lane_mask_and_gap_filter(infile, lane_mask,
-                                                 opts.allowed_gap_frac, verbose=opts.verbose,
+                                                 opts.allowed_gap_frac,
                                                  entropy_threshold=opts.entropy_threshold)
 
         filtered_aln = remove_outliers(seq_gen, opts.threshold)
-        for seq in filtered_aln.Seqs:
-            outfile.write(seq.toFasta())
+        for seq in filtered_aln:
+            outfile.write(seq.to_fasta())
             outfile.write('\n')
 
     else:
         # just apply the lanemask/gap removal
         for result in apply_lane_mask_and_gap_filter(infile, lane_mask,
-                                                     opts.allowed_gap_frac, verbose=opts.verbose,
+                                                     opts.allowed_gap_frac,
                                                      entropy_threshold=opts.entropy_threshold):
             outfile.write(result)
     infile.close()

--- a/scripts/filter_alignment.py
+++ b/scripts/filter_alignment.py
@@ -47,8 +47,9 @@ script_info[
     'output_description'] = """The output of filter_alignment.py consists of a single FASTA file, which ends with "pfiltered.fasta", where the "p" stands for positional filtering of the columns."""
 
 script_info['required_options'] = [
-    make_option('-i', '--input_fasta_file', action='store',
-                type='existing_filepath', help='the input directory ')
+    make_option('-i', '--input_fasta_file',
+                type='existing_filepath',
+                help='the input fasta file containing the alignment')
 ]
 
 qiime_config = load_qiime_config()
@@ -69,7 +70,7 @@ script_info['optional_options'] = [
                 type='float', help='gap filter threshold, ' +
                 'filters positions which are gaps in > allowed_gap_frac ' +
                 'of the sequences [default: %default]',
-                default=1. - np.finfo(float).eps),
+                default=1.-1e-6),
     make_option('-r', '--remove_outliers', action='store_true',
                 help='remove seqs very dissimilar to the alignment consensus' +
                 ' (see --threshold).  [default: %default]',

--- a/tests/test_filter_alignment.py
+++ b/tests/test_filter_alignment.py
@@ -12,16 +12,15 @@ from unittest import TestCase, main
 
 from numpy import array
 from numpy.testing import assert_almost_equal
+from skbio import parse_fasta, Alignment, DNA
 
-from qiime.filter_alignment import (
-    apply_lane_mask, apply_gap_filter, apply_lane_mask_and_gap_filter,
+from qiime.filter_alignment import (apply_lane_mask_and_gap_filter,
     remove_outliers, generate_lane_mask)
 
 
 class FilterAlignmentTests(TestCase):
 
     def setUp(self):
-        """Init variables for the tests """
         self.aln1 = [
             '>s1', 'ACC--T',
             '>s2', 'AC---T',
@@ -33,15 +32,34 @@ class FilterAlignmentTests(TestCase):
         self.aln2_lm = aln2_lm
 
     def test_apply_lane_mask_and_gap_filter_real(self):
-        """apply_lane_mask_and_gap_filter: no error on full length seqs
-        """
         # No error when applying to full-length sequence
         actual = apply_lane_mask_and_gap_filter(
             self.aln2, self.aln2_lm)
 
-    def test_apply_lane_mask_and_gap_filter(self):
-        """apply_lane_mask_and_gap_filter: functions as expected
-        """
+    def test_apply_lane_mask_and_gap_filter_invalid(self):
+        # passing both a mask and an entropy threshold results in a ValueError
+        with self.assertRaises(ValueError):
+            list(apply_lane_mask_and_gap_filter(self.aln1, '111111',
+                                                entropy_threshold=0.0))
+
+    def test_apply_lane_mask_and_gap_filter_w_entropy_threshold(self):
+        expected = self.aln1.__iter__()
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 1.0,
+                                                     entropy_threshold=0.0):
+            self.assertEqual(result, expected.next() + '\n')
+
+        expected = [
+            '>s1', '',
+            '>s2', '',
+            '>s3', '',
+            '>s4', '',
+            '>s5', ''
+        ].__iter__()
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 1.0,
+                                                     entropy_threshold=1.0):
+            self.assertEqual(result, expected.next() + '\n')
+
+    def test_apply_lane_mask_and_gap_filter_w_precomputed_mask(self):
         lm = '111111'
         expected = self.aln1.__iter__()
         for result in apply_lane_mask_and_gap_filter(self.aln1, lm, 1.0):
@@ -91,12 +109,10 @@ class FilterAlignmentTests(TestCase):
         for result in apply_lane_mask_and_gap_filter(self.aln1, lm):
             self.assertEqual(result, expected.next() + '\n')
 
-    def test_apply_lane_mask(self):
-        """ apply_lane_mask: functions as expected with varied lane masks
-        """
+    def test_apply_lane_mask_only(self):
         lm1 = '111111'
         expected = self.aln1.__iter__()
-        for result in apply_lane_mask(self.aln1, lm1):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, lm1, 1):
             self.assertEqual(result, expected.next() + '\n')
 
         lm2 = '000000'
@@ -108,7 +124,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', ''
         ].__iter__()
 
-        for result in apply_lane_mask(self.aln1, lm2):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, lm2, 1):
             self.assertEqual(result, expected.next() + '\n')
 
         lm3 = '101010'
@@ -120,7 +136,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', '---'
         ].__iter__()
 
-        for result in apply_lane_mask(self.aln1, lm3):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, lm3, 1):
             self.assertEqual(result, expected.next() + '\n')
 
         lm4 = '000111'
@@ -132,15 +148,13 @@ class FilterAlignmentTests(TestCase):
             '>s5', 'A--'
         ].__iter__()
 
-        for result in apply_lane_mask(self.aln1, lm4):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, lm4, 1):
             self.assertEqual(result, expected.next() + '\n')
 
-    def test_apply_gap_filter(self):
-        """ apply_gap_filter: functions as expected with varied allowed_gap_frac
-        """
+    def test_apply_gap_filter_only(self):
         expected = self.aln1.__iter__()
 
-        for result in apply_gap_filter(self.aln1, 1.0):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 1.0):
             self.assertEqual(result, expected.next() + '\n')
 
         expected = [
@@ -151,7 +165,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', '---A-'
         ].__iter__()
 
-        for result in apply_gap_filter(self.aln1):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None):
             self.assertEqual(result, expected.next() + '\n')
 
         expected = [
@@ -162,7 +176,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', '----'
         ].__iter__()
 
-        for result in apply_gap_filter(self.aln1, 0.75):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 0.75):
             self.assertEqual(result, expected.next() + '\n')
 
         expected = [
@@ -173,7 +187,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', '----'
         ].__iter__()
 
-        for result in apply_gap_filter(self.aln1, 0.40):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 0.40):
             self.assertEqual(result, expected.next() + '\n')
 
         expected = [
@@ -184,7 +198,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', '---'
         ].__iter__()
 
-        for result in apply_gap_filter(self.aln1, 0.30):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 0.30):
             self.assertEqual(result, expected.next() + '\n')
 
         expected = [
@@ -195,7 +209,7 @@ class FilterAlignmentTests(TestCase):
             '>s5', ''
         ].__iter__()
 
-        for result in apply_gap_filter(self.aln1, 0.10):
+        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 0.10):
             self.assertEqual(result, expected.next() + '\n')
 
         # the following tests were adapted from test_alignment.py in PyCogent
@@ -212,7 +226,7 @@ class FilterAlignmentTests(TestCase):
             '>b', 'CBA-',
             '>c', '-DEF'
         ].__iter__()
-        for result in apply_gap_filter(aln):
+        for result in apply_lane_mask_and_gap_filter(aln, None):
             self.assertEqual(result, expected.next() + '\n')
 
         # if allowed_gap_frac is 1, shouldn't delete anything
@@ -221,7 +235,7 @@ class FilterAlignmentTests(TestCase):
             '>b', '-CB-A--',
             '>c', '--D-EF-'
         ].__iter__()
-        for result in apply_gap_filter(aln, 1):
+        for result in apply_lane_mask_and_gap_filter(aln, None, 1):
             self.assertEqual(result, expected.next() + '\n')
 
         # if allowed_gap_frac is 0, should strip out any cols containing gaps
@@ -230,7 +244,7 @@ class FilterAlignmentTests(TestCase):
             '>b', 'BA',
             '>c', 'DE'
         ].__iter__()
-        for result in apply_gap_filter(aln, 0):
+        for result in apply_lane_mask_and_gap_filter(aln, None, 0):
             self.assertEqual(result, expected.next() + '\n')
 
         # intermediate numbers should work as expected
@@ -239,19 +253,17 @@ class FilterAlignmentTests(TestCase):
             '>b', 'BA-',
             '>c', 'DEF'
         ].__iter__()
-        for result in apply_gap_filter(aln, 0.4):
+        for result in apply_lane_mask_and_gap_filter(aln, None, 0.4):
             self.assertEqual(result, expected.next() + '\n')
         expected = [
             '>a', '-ABC',
             '>b', 'CBA-',
             '>c', '-DEF'
         ].__iter__()
-        for result in apply_gap_filter(aln, 0.7):
+        for result in apply_lane_mask_and_gap_filter(aln, None, 0.7):
             self.assertEqual(result, expected.next() + '\n')
 
     def test_apply_lane_mask_and_gap_filter_alternate_alignment(self):
-        """apply_lane_mask_and_gap_filter: functions as expected with alt aln
-        """
         aln = [
             '>ACT009', 'AACT-',
             '>ACT019', 'AACT-',
@@ -271,7 +283,6 @@ class FilterAlignmentTests(TestCase):
             self.assertEqual(result, expected.next() + '\n')
 
     def test_remove_outliers(self):
-        """ remove outliers returns only seqs similar to consensus"""
         aln = [
             '>ACT009', 'ACAT-',
             '>ACT019', 'GACT-',
@@ -308,25 +319,31 @@ class FilterAlignmentTests(TestCase):
         self.assertTrue('ACT009' not in res.ids())
 
     def test_generate_lane_mask(self):
-        """ Generates correct lane mask for dynamic entropy filtering """
 
         sample_alignment = """>1
-        .ATC-G
+        AAAAT
         >2
-        .AACCG
+        AAAGG
         >3
-        .ATC-G
+        AACCC
         >4
-        .AAC-G""".split('\n')
+        A----""".split('\n')
+        aln = Alignment.from_fasta_records(parse_fasta(sample_alignment), DNA)
 
-        entropy_threshold = 0.70
-
-        expected_lanemask = "110101"
-
-        actual_lanemask = generate_lane_mask(sample_alignment,
-                                             entropy_threshold)
-
-        self.assertEqual(actual_lanemask, expected_lanemask)
+        actual_lanemask = generate_lane_mask(aln, 0.00)
+        self.assertEqual(actual_lanemask, "11111")
+        actual_lanemask = generate_lane_mask(aln, 0.10)
+        self.assertEqual(actual_lanemask, "11100")
+        actual_lanemask = generate_lane_mask(aln, 0.20)
+        self.assertEqual(actual_lanemask, "11100")
+        actual_lanemask = generate_lane_mask(aln, 0.40)
+        self.assertEqual(actual_lanemask, "11000")
+        actual_lanemask = generate_lane_mask(aln, 0.60)
+        self.assertEqual(actual_lanemask, "11000")
+        actual_lanemask = generate_lane_mask(aln, 0.80)
+        self.assertEqual(actual_lanemask, "10000")
+        actual_lanemask = generate_lane_mask(aln, 1.00)
+        self.assertEqual(actual_lanemask, "00000")
 
 aln2_fasta = """>1121 HalF20SW_57886 RC:1..219
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------A--AT-GT-A-T-A-GT---TAA--T-CT-G--C-C-CCA--TA-G------------------------------------------------------------------T-GG----AGG-AC-AA-CAG-------------------------T-T-A-----------------------GAA-A---TGA-CTG-CTAA-TA---CT-C--C-AT-A----------C--------------------T-C--C-T-T--C--T-----------------T----AT-C-----------------------------------------------------------------------------------------------------------------------A-TA-A--------------------------------------------------------------------------------------------------------------------------------------G-T-T----A---------------A--G-T-C-G-G-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------GAAA--G-T----------------------------------------------------------------------------------------------------------------------------------------TTT------------------------------------------------------------------------------------------------------------------------------------T---C-G--------------C----T-A---T-GG-G---AT---G-A-----G-ACT-ATA--T-CGT--A------TC--A--G-CT-A----G---TTGG-T-A-AG-G-T----AAT-GG-C-T-T-ACCA--A-GG-C-T--A-TG-A------------CGC-G-T------AA-CT-G-G-TCT-G-AG----A--GG-AT--G-AT-C-AG-TCAC-A-TTGGA--A-C-TG-A-GA-C-AC-G-G-TCCAA------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/tests/test_filter_alignment.py
+++ b/tests/test_filter_alignment.py
@@ -48,16 +48,10 @@ class FilterAlignmentTests(TestCase):
                                                      entropy_threshold=0.0):
             self.assertEqual(result, expected.next() + '\n')
 
-        expected = [
-            '>s1', '',
-            '>s2', '',
-            '>s3', '',
-            '>s4', '',
-            '>s5', ''
-        ].__iter__()
-        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 1.0,
-                                                     entropy_threshold=1.0):
-            self.assertEqual(result, expected.next() + '\n')
+        # filtering all positions results in a ValueError
+        with self.assertRaises(ValueError):
+            list(apply_lane_mask_and_gap_filter(self.aln1, None, 1.0,
+                                                entropy_threshold=1.0))
 
     def test_apply_lane_mask_and_gap_filter_w_precomputed_mask(self):
         lm = '111111'
@@ -115,17 +109,10 @@ class FilterAlignmentTests(TestCase):
         for result in apply_lane_mask_and_gap_filter(self.aln1, lm1, 1):
             self.assertEqual(result, expected.next() + '\n')
 
+        # filtering all positions results in a ValueError
         lm2 = '000000'
-        expected = [
-            '>s1', '',
-            '>s2', '',
-            '>s3', '',
-            '>s4', '',
-            '>s5', ''
-        ].__iter__()
-
-        for result in apply_lane_mask_and_gap_filter(self.aln1, lm2, 1):
-            self.assertEqual(result, expected.next() + '\n')
+        with self.assertRaises(ValueError):
+            list(apply_lane_mask_and_gap_filter(self.aln1, lm2, 1))
 
         lm3 = '101010'
         expected = [
@@ -201,16 +188,9 @@ class FilterAlignmentTests(TestCase):
         for result in apply_lane_mask_and_gap_filter(self.aln1, None, 0.30):
             self.assertEqual(result, expected.next() + '\n')
 
-        expected = [
-            '>s1', '',
-            '>s2', '',
-            '>s3', '',
-            '>s4', '',
-            '>s5', ''
-        ].__iter__()
-
-        for result in apply_lane_mask_and_gap_filter(self.aln1, None, 0.10):
-            self.assertEqual(result, expected.next() + '\n')
+        # filtering all positions results in a ValueError
+        with self.assertRaises(ValueError):
+            list(apply_lane_mask_and_gap_filter(self.aln1, None, 0.10))
 
         # the following tests were adapted from test_alignment.py in PyCogent
 


### PR DESCRIPTION
this addresses #1824, simplifies the code, and addresses an issue in the development version of QIIME where positions that were 100% gaps were not being filtered by default. 

@jairideout and I pair programmed this.

~~**NOT READY FOR MERGE**: we're going to compare the resulting filtered alignment here with the one generated in 1.7.0 on AWS.~~