### PR TITLE
TST: update test_identify_chimeric_seqs.py to work with latest default pynast_template_alignment_fp

### DIFF
--- a/tests/test_parallel/test_identify_chimeric_seqs.py
+++ b/tests/test_parallel/test_identify_chimeric_seqs.py
@@ -120,7 +120,7 @@ class ParallelChimericSequenceIdentifierTests(TestCase):
         # Basic sanity check: we should get two lines (i.e. two chimeras).
         results = [line for line in open(join(self.test_out,
                    'ChimeraSlayer_out.txt'), 'U')]
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 1)
 
 # This test data is taken from qiime_test_data.
 in_seqs = """


### PR DESCRIPTION
This is necessary now that we've updated the default pynast_template_alignment_fp to 85% Greengenes (previously was the core set).

Addresses part of #1836.