### PR TITLE
BUG: fix generation of per-subcategory plots in make_rarefaction_plots.py

### DIFF
--- a/qiime/make_rarefaction_plots.py
+++ b/qiime/make_rarefaction_plots.py
@@ -895,6 +895,7 @@ def make_plots(background_color, label_color, rares, ymax, xmax,
                              splitext(split(raredata['headers'][0])[1])[0])
 
     all_plots_single = []
+    all_plots_ave = []
     # Sort and iterate through the groups
     for i in natsort(groups):
         # for k in groups[i]:
@@ -949,10 +950,11 @@ def make_plots(background_color, label_color, rares, ymax, xmax,
                     ''.join('%10.3f' %
                             ((raredata['error'][i][j]))))
 
-        # Create raw plots for each group in a category
-        fpath = output_dir
-
         if generate_per_sample_plots:
+            # Create raw plots for each group in a category
+            fpath = output_dir
+            categories = [k for k in groups]
+
             if output_type == "file_creation":
                 rarefaction_legend_mat = save_single_rarefaction_plots(
                     sample_dict,
@@ -962,6 +964,15 @@ def make_plots(background_color, label_color, rares, ymax, xmax,
                     label_color, resolution, ymax, xmax,
                     rarefaction_legend_mat, groups[i],
                     labelname, i, mapping_lookup, output_type)
+
+                rarefaction_legend_mat = save_single_ave_rarefaction_plots(
+                    raredata['xaxis'],
+                    raredata['series'], raredata[
+                        'error'], xmax, ymax, categories,
+                    labelname, imagetype, resolution, data_colors,
+                    colors, file_path, background_color, label_color,
+                    rarefaction_legend_mat, metric_name, mapping_lookup,
+                    output_type)
             elif output_type == "memory":
                 rarefaction_legend_mat, rare_plot_for_all = save_single_rarefaction_plots(
                     sample_dict,
@@ -973,31 +984,22 @@ def make_plots(background_color, label_color, rares, ymax, xmax,
                     labelname, i, mapping_lookup, output_type)
                 all_plots_single.append(rare_plot_for_all)
 
-    categories = [k for k in groups]
+                rarefaction_legend_mat, rare_plot_for_ave = save_single_ave_rarefaction_plots(
+                    raredata['xaxis'],
+                    raredata['series'], raredata[
+                        'error'], xmax, ymax, categories,
+                    labelname, imagetype, resolution, data_colors,
+                    colors, file_path, background_color, label_color,
+                    rarefaction_legend_mat, metric_name, mapping_lookup,
+                    output_type)
+                all_plots_ave.append(rare_plot_for_ave)
 
     # Create the rarefaction average plot and get updated legend information
     if output_type == "file_creation":
-        rarefaction_legend_mat = save_single_ave_rarefaction_plots(
-            raredata['xaxis'],
-            raredata['series'], raredata[
-                'error'], xmax, ymax, categories,
-            labelname, imagetype, resolution, data_colors,
-            colors, file_path, background_color, label_color,
-            rarefaction_legend_mat, metric_name, mapping_lookup, output_type)
-
         return rarefaction_data_mat, rarefaction_legend_mat
     elif output_type == "memory":
-        rarefaction_legend_mat, all_plots_ave = save_single_ave_rarefaction_plots(
-            raredata['xaxis'],
-            raredata['series'], raredata[
-                'error'], xmax, ymax, categories,
-            labelname, imagetype, resolution, data_colors,
-            colors, file_path, background_color, label_color,
-            rarefaction_legend_mat, metric_name, mapping_lookup, output_type)
-
-        return (
-            rarefaction_data_mat, rarefaction_legend_mat, all_plots_single, all_plots_ave
-        )
+        return (rarefaction_data_mat, rarefaction_legend_mat, all_plots_single,
+                all_plots_ave)
 
 
 HTML = '''

--- a/scripts/make_rarefaction_plots.py
+++ b/scripts/make_rarefaction_plots.py
@@ -52,7 +52,7 @@ script_info['script_usage'].append(("""Set Background Color:""",
 script_info[
     'script_usage'].append(("""Generate raw data without interactive webpages:""",
                             "The user can choose to not create an interactive webpage ('-w' option). "
-                            "This is for the case, where the user just wants the average plots and the"
+                            "This is for the case, where the user just wants the average plots and the "
                             "raw average data.",
                             """%prog -i alpha_div_collated/ -m Fasting_Map.txt -w"""))
 
@@ -118,7 +118,7 @@ script_info['optional_options'] = [
     options_lookup['output_dir'],
     make_option('--output_type', default='file_creation', type="choice",
                 help='Write the HTML output as one file, images embedded, or several. Options' +
-                ' are file_creation, multiple files, and memory. [default: %default]',
+                ' are "file_creation" and "memory". [default: %default]',
                 choices=['file_creation', 'memory']),
     make_option('--generate_per_sample_plots', action='store_true', help='generate per '
                 'sample plots for each of the metadata categories. This will allow you to '


### PR DESCRIPTION
Per-subcategory plots were being created in the current directory if `--generate_per_sample_plots` wasn't supplied (default behavior). These plots are now only generated if `--generate_per_sample_plots` is supplied, and they are created in the correct subdirectory under `--output_dir`.

Fixes #1852.