### PR TITLE
MAINT: use biom.load_table instead of biom.parse.parse_biom_table

### DIFF
--- a/qiime/beta_diversity.py
+++ b/qiime/beta_diversity.py
@@ -36,8 +36,6 @@ warnings.filterwarnings('ignore', 'Not using MPI as mpi4py not found')
 
 from numpy import asarray
 import cogent.maths.distance_transform as distance_transform
-from biom.parse import parse_biom_table
-from biom.table import Table
 from biom import load_table
 
 from qiime.util import (FunctionWithParams, TreeMissingError,

--- a/qiime/otu_significance.py
+++ b/qiime/otu_significance.py
@@ -41,7 +41,7 @@ Some abbreviations that are used in this code are:
 pmf - parsed mapping file. Nested dict created by parse_mapping_file_to_dict
  which has as top level keys the sample IDs and then all assocaited metadata
  in a dictionary with the mapping file column headers as keys.
-bt - biom table object. Created with parse_biom_table.
+bt - biom table object.
 row - row is used in several places (eg. row_generator). The 'row' being
  returned is actually a list of arrays that comes from a single row, and a
  collection of grouped columns from the OTU table (for the group significance

--- a/qiime/rarefaction.py
+++ b/qiime/rarefaction.py
@@ -32,11 +32,10 @@ class SingleRarefactionMaker(FunctionWithParams):
     def __init__(self, otu_path, depth):
         """ init a singlerarefactionmaker
 
-        otu_path has to be parseable when opened by parse_biom_table,
+        otu_path has to be a parseable BIOM table,
         we just ignore any rarefaction levels beyond any sample in the data
         """
         self.depth = depth
-        #self.otu_table = parse_biom_table(open(otu_path,'U'))
         self.otu_table = self.getBiomData(otu_path)
 
         self.max_num_taxa = -1

--- a/qiime/util.py
+++ b/qiime/util.py
@@ -39,7 +39,6 @@ from numpy.ma.extras import apply_along_axis
 
 from biom.util import compute_counts_per_sample_stats, biom_open, HAVE_H5PY
 from biom import load_table
-from biom.parse import parse_biom_table
 from biom.table import Table
 
 from cogent.parse.tree import DndParser
@@ -2122,7 +2121,7 @@ def sync_biom_and_mf(pmf, bt):
 
     Inputs:
      pmf - parsed mapping file from parse_mapping_file_to_dict (nested dict).
-     bt - parse biom table from parse_biom_table (biom table object).
+     bt - biom table object.
     Outputs are a bt and pmf that contain only shared samples and a set of
     samples that are not shared. If no samples are unshared this final output
     will be an empty set.

--- a/scripts/compute_core_microbiome.py
+++ b/scripts/compute_core_microbiome.py
@@ -17,8 +17,7 @@ use('Agg', warn=False)
 from pylab import xlim, ylim, xlabel, ylabel, plot, savefig
 import numpy as np
 from skbio.util import create_dir
-from biom.parse import parse_biom_table
-from biom.util import biom_open
+from biom import load_table
 from biom.exception import TableException
 
 from qiime.util import (parse_command_line_parameters, make_option,
@@ -104,8 +103,7 @@ def main():
         # samples to work with
         sample_ids = None
 
-    with biom_open(input_fp, 'U') as f:
-        input_table = parse_biom_table(f)
+    input_table = load_table(input_fp)
 
     otu_counts = []
     summary_figure_fp = join(output_dir, 'core_otu_size.pdf')

--- a/scripts/make_tep.py
+++ b/scripts/make_tep.py
@@ -13,7 +13,6 @@ __email__ = "meganap@gmail.com"
 from os.path import split, splitext
 import os
 
-from biom.parse import parse_biom_table
 from biom import load_table
 
 from qiime.util import parse_command_line_parameters, make_option

--- a/scripts/plot_rank_abundance_graph.py
+++ b/scripts/plot_rank_abundance_graph.py
@@ -10,7 +10,6 @@ __version__ = "1.9.0-rc2"
 __maintainer__ = "Justin Kuczynski"
 __email__ = "justinak@gmail.com"
 
-from biom.parse import parse_biom_table
 from biom import load_table
 
 from qiime.util import make_option

--- a/scripts/simsam.py
+++ b/scripts/simsam.py
@@ -13,7 +13,6 @@ __email__ = "justinak@gmail.com"
 from os.path import join, split, splitext
 
 from cogent.parse.tree import DndParser
-from biom.parse import parse_biom_table
 from biom import load_table
 
 from qiime.util import (add_filename_suffix, create_dir, get_options_lookup,

--- a/scripts/sort_otu_table.py
+++ b/scripts/sort_otu_table.py
@@ -11,7 +11,6 @@ __version__ = "1.9.0-rc2"
 __maintainer__ = "Greg Caporaso"
 __email__ = "gregcaporaso@gmail.com"
 
-from biom.parse import parse_biom_table
 from biom import load_table
 
 from qiime.parse import parse_mapping_file

--- a/scripts/split_otu_table_by_taxonomy.py
+++ b/scripts/split_otu_table_by_taxonomy.py
@@ -13,7 +13,6 @@ __email__ = "gregcaporaso@gmail.com"
 
 from os.path import split
 
-from biom.parse import parse_biom_table
 from biom import load_table
 
 from qiime.util import (parse_command_line_parameters, get_options_lookup,

--- a/tests/test_beta_diversity.py
+++ b/tests/test_beta_diversity.py
@@ -18,7 +18,6 @@ from tempfile import mkstemp, mkdtemp
 from unittest import TestCase, main
 
 from biom.table import Table
-from biom.util import biom_open
 import numpy as np
 import numpy.testing as npt
 from skbio.util import remove_files


### PR DESCRIPTION
Updated all user-facing code to use `biom.load_table` instead of
`biom.parse.parse_biom_table` for consistency. I didn't update the unit tests
because this isn't user-facing and most of the unit tests provide a string or
list of strings representing a JSON BIOM file, which `load_table` doesn't
support.

Fixes #1859.