### PR TITLE
BUG: fix generation of per-subcategory plots in make_rarefaction_plots.py (redux)

### DIFF
--- a/qiime/make_rarefaction_plots.py
+++ b/qiime/make_rarefaction_plots.py
@@ -950,15 +950,13 @@ def make_plots(background_color, label_color, rares, ymax, xmax,
                             ((raredata['error'][i][j]))))
 
         # Create raw plots for each group in a category
-        fpath = output_dir
-
         if generate_per_sample_plots:
             if output_type == "file_creation":
                 rarefaction_legend_mat = save_single_rarefaction_plots(
                     sample_dict,
                     imagetype, metric_name,
                     sample_data_colors, sample_colors,
-                    fpath, background_color,
+                    output_dir, background_color,
                     label_color, resolution, ymax, xmax,
                     rarefaction_legend_mat, groups[i],
                     labelname, i, mapping_lookup, output_type)
@@ -967,34 +965,37 @@ def make_plots(background_color, label_color, rares, ymax, xmax,
                     sample_dict,
                     imagetype, metric_name,
                     sample_data_colors, sample_colors,
-                    fpath, background_color,
+                    output_dir, background_color,
                     label_color, resolution, ymax, xmax,
                     rarefaction_legend_mat, groups[i],
                     labelname, i, mapping_lookup, output_type)
                 all_plots_single.append(rare_plot_for_all)
 
-    categories = [k for k in groups]
+    all_plots_ave = {}
+    if generate_per_sample_plots:
+        # Create the rarefaction average plot and get updated legend information
+        categories = [k for k in groups]
 
-    # Create the rarefaction average plot and get updated legend information
+        if output_type == "file_creation":
+            rarefaction_legend_mat = save_single_ave_rarefaction_plots(
+                raredata['xaxis'],
+                raredata['series'], raredata[
+                    'error'], xmax, ymax, categories,
+                labelname, imagetype, resolution, data_colors,
+                colors, file_path, background_color, label_color,
+                rarefaction_legend_mat, metric_name, mapping_lookup, output_type)
+        elif output_type == "memory":
+            rarefaction_legend_mat, all_plots_ave = save_single_ave_rarefaction_plots(
+                raredata['xaxis'],
+                raredata['series'], raredata[
+                    'error'], xmax, ymax, categories,
+                labelname, imagetype, resolution, data_colors,
+                colors, file_path, background_color, label_color,
+                rarefaction_legend_mat, metric_name, mapping_lookup, output_type)
+
     if output_type == "file_creation":
-        rarefaction_legend_mat = save_single_ave_rarefaction_plots(
-            raredata['xaxis'],
-            raredata['series'], raredata[
-                'error'], xmax, ymax, categories,
-            labelname, imagetype, resolution, data_colors,
-            colors, file_path, background_color, label_color,
-            rarefaction_legend_mat, metric_name, mapping_lookup, output_type)
-
         return rarefaction_data_mat, rarefaction_legend_mat
     elif output_type == "memory":
-        rarefaction_legend_mat, all_plots_ave = save_single_ave_rarefaction_plots(
-            raredata['xaxis'],
-            raredata['series'], raredata[
-                'error'], xmax, ymax, categories,
-            labelname, imagetype, resolution, data_colors,
-            colors, file_path, background_color, label_color,
-            rarefaction_legend_mat, metric_name, mapping_lookup, output_type)
-
         return (
             rarefaction_data_mat, rarefaction_legend_mat, all_plots_single, all_plots_ave
         )

--- a/scripts/make_rarefaction_plots.py
+++ b/scripts/make_rarefaction_plots.py
@@ -52,7 +52,7 @@ script_info['script_usage'].append(("""Set Background Color:""",
 script_info[
     'script_usage'].append(("""Generate raw data without interactive webpages:""",
                             "The user can choose to not create an interactive webpage ('-w' option). "
-                            "This is for the case, where the user just wants the average plots and the"
+                            "This is for the case, where the user just wants the average plots and the "
                             "raw average data.",
                             """%prog -i alpha_div_collated/ -m Fasting_Map.txt -w"""))
 
@@ -118,7 +118,7 @@ script_info['optional_options'] = [
     options_lookup['output_dir'],
     make_option('--output_type', default='file_creation', type="choice",
                 help='Write the HTML output as one file, images embedded, or several. Options' +
-                ' are file_creation, multiple files, and memory. [default: %default]',
+                ' are "file_creation" and "memory". [default: %default]',
                 choices=['file_creation', 'memory']),
     make_option('--generate_per_sample_plots', action='store_true', help='generate per '
                 'sample plots for each of the metadata categories. This will allow you to '


### PR DESCRIPTION
Per-subcategory plots were being created in the current directory if `--generate_per_sample_plots` wasn't supplied (default behavior). These plots are now only generated if `--generate_per_sample_plots` is supplied, and they are created in the correct subdirectory under `--output_dir`.

Fixes #1852.

This pull request replaces #1858.