### PR TITLE
ENH: clarify error message in qiime.util.MetadataMap.filterSamples

### DIFF
--- a/qiime/util.py
+++ b/qiime/util.py
@@ -1913,8 +1913,11 @@ class MetadataMap():
             extra_samples = set(sample_ids_to_keep) - set(self.sample_ids)
 
             if extra_samples:
-                raise ValueError("Could not find the following sample IDs in "
-                                 "metadata map: %s" % ', '.join(extra_samples))
+                extra_samples_formatted = ', '.join(
+                    map(lambda e: '"%s"' % e, extra_samples))
+                raise ValueError(
+                    "Could not find the following sample ID(s) in the "
+                    "metadata mapping file: %s" % extra_samples_formatted)
 
 
 class RExecutor(CommandLineApplication):


### PR DESCRIPTION
This issue came up in this QIIME forum post:

https://groups.google.com/d/topic/qiime-forum/aFYlu5lnsgI/discussion

The new error message quotes each sample ID so that it's clearer what the IDs
are. I also updated the error message text slightly to make it more
user-friendly.