### PR TITLE
ENH: status indication when installing non-Python dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ pip-log.txt
 .metadata
 build
 
-# compile denoiser files
+# compiled denoiser files
 qiime/support_files/denoiser/FlowgramAlignment/ADPCombinators.hi
 qiime/support_files/denoiser/FlowgramAlignment/ADPCombinators.o
 qiime/support_files/denoiser/FlowgramAlignment/FlowgramAli_4frame

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,12 @@ global-exclude .git
 global-exclude FastTree
 global-exclude uclust
 global-exclude FlowgramAli_4frame
+global-exclude indexdb_rna
+global-exclude sortmerna
+global-exclude sumaclust
+global-exclude swarm
+global-exclude amplicon_contingency_table.py
+global-exclude swarm_breaker.py
 global-exclude *.hi
 global-exclude *.o
 global-exclude qiime_test_data

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ J. Gregory Caporaso, Justin Kuczynski, Jesse Stombaugh, Kyle Bittinger, Frederic
 Nature Methods, 2010.
 """
 
-# if egg_info is passed as an argument do not build any of the dependencies
-build_stack = 'egg_info' not in argv
-
+# don't build any of the non-Python dependencies if the following modes are
+# invoked
+build_stack = all([e not in argv for e in 'egg_info', 'sdist', 'register'])
 
 def build_denoiser():
     """ Build the denoiser code binary """


### PR DESCRIPTION
Status messages are provided while non-Python dependencies are installed via setup.py. Also fixed bug where these built dependencies would have been bundled with our source distribution.

Status output now looks like the following (updated progressively instead of dumping all text when finished):

```
Running setup.py develop for qiime
    Building denoiser...
    Denoiser built.

    Installing UCLUST...
      Downloading uclust...
      uclust downloaded successfully.
    UCLUST installed.

    Building FastTree...
      Downloading FastTree.c...
      FastTree.c downloaded successfully.
    FastTree built.

    Building SortMeRNA...
      Downloading sortmerna-2.0-no-db.tar.gz...
      sortmerna-2.0-no-db.tar.gz downloaded successfully.
    SortMeRNA built.

    Building SUMACLUST...
      Downloading suma_package_V_1.0.00.tar.gz...
      suma_package_V_1.0.00.tar.gz downloaded successfully.
    Unable to build SUMACLUST:
      stdout:
        gcc -O3 -s -fopenmp -w -c -o sumaclust.o sumaclust.c -lfasta -llcs -lfile -lutils -lm
        gcc -O3 -s -fopenmp -w -c -o mtcompare_sumaclust.o mtcompare_sumaclust.c -lfasta -llcs -lfile -lutils -lm
        /Applications/Xcode.app/Contents/Developer/usr/bin/make -C ../libfasta
        gcc -O3 -s -fopenmp -w -c -o fasta_header_parser.o fasta_header_parser.c
        gcc -O3 -s -fopenmp -w -c -o fasta_seq_writer.o fasta_seq_writer.c
        gcc -O3 -s -fopenmp -w -c -o fasta_header_handler.o fasta_header_handler.c
        gcc -O3 -s -fopenmp -w -c -o header_mem_handler.o header_mem_handler.c
        gcc -O3 -s -fopenmp -w -c -o sequence.o sequence.c
        ar -cr libfasta.a fasta_header_parser.o fasta_seq_writer.o fasta_header_handler.o header_mem_handler.o sequence.o
        ranlib libfasta.a
        /Applications/Xcode.app/Contents/Developer/usr/bin/make -C ../liblcs
        gcc -O3 -s -fopenmp -w -c -o sse_banded_LCS_alignment.o sse_banded_LCS_alignment.c
        gcc -O3 -s -fopenmp -w -c -o upperband.o upperband.c
        ar -cr liblcs.a sse_banded_LCS_alignment.o upperband.o
        ranlib liblcs.a
        /Applications/Xcode.app/Contents/Developer/usr/bin/make -C ../libfile
        gcc -O3 -s -fopenmp -w -c -o fileHandling.o fileHandling.c
        ar -cr libfile.a fileHandling.o
        ranlib libfile.a
        /Applications/Xcode.app/Contents/Developer/usr/bin/make -C ../libutils
        gcc -O3 -s -fopenmp -w -c -o utilities.o utilities.c
        gcc -O3 -s -fopenmp -w -c -o debug.o debug.c
        ar -cr libutils.a utilities.o debug.o
        ranlib libutils.a
        gcc  -o sumaclust -fopenmp sumaclust.o mtcompare_sumaclust.o -lfasta -llcs -lfile -lutils -lm  -L../libfasta -L../liblcs -L../libfile -L../libutils

      stderr:
        ld: library not found for -lgomp
        clang: error: linker command failed with exit code 1 (use -v to see invocation)
        make: *** [sumaclust] Error 1

    Building swarm...
      Downloading swarm-1.2.19.tar.gz...
      swarm-1.2.19.tar.gz downloaded successfully.
    swarm built.
```

Fixes #1869.