### PR TITLE
By default set BIOM table type to "OTU table"

### DIFF
--- a/qiime/util.py
+++ b/qiime/util.py
@@ -530,7 +530,7 @@ def get_generated_by_for_biom_tables():
 
 
 def write_biom_table(biom_table, biom_table_fp, compress=True,
-                     write_hdf5=HAVE_H5PY):
+                     write_hdf5=HAVE_H5PY, type='OTU table'):
     """Writes a BIOM table to the specified filepath
 
     Parameters
@@ -549,6 +549,7 @@ def write_biom_table(biom_table, biom_table_fp, compress=True,
         HDF5 binary file, otherwise it will be a JSON string.
     """
     generated_by = get_generated_by_for_biom_tables()
+    biom_table.type = type
 
     if write_hdf5:
         with biom_open(biom_table_fp, 'w') as biom_file:


### PR DESCRIPTION
Cleaner version of #1937, fix for #1928.