### PR TITLE
Fix documentation of split_libraries_fastq

### DIFF
--- a/doc/scripts/split_libraries_fastq.rst
+++ b/doc/scripts/split_libraries_fastq.rst
@@ -45,7 +45,7 @@ In both these cases, this script can be used to demultiplex the reads.fastq file
 		The barcode read fastq files (comma-separated if more than one) [default: None]
 	`-`-store_qual_scores
 		Store qual strings in .qual files [default: False]
-	`-`-sample_id
+	`-`-sample_ids
 		Comma-separated list of samples id to be applied to all sequences, must be one per input file path (used when data is not multiplexed) [default: None]
 	`-`-store_demultiplexed_fastq
 		Write demultiplexed fastq files [default: False]
@@ -104,12 +104,12 @@ In both these cases, this script can be used to demultiplex the reads.fastq file
 
 ::
 
-	split_libraries_fastq.py -i lane1_read1.fastq.gz --sample_id my.sample.1 -o slout_single_sample_q20/ -q 19 --barcode_type 'not-barcoded'
+	split_libraries_fastq.py -i lane1_read1.fastq.gz --sample_ids my.sample.1 -o slout_single_sample_q20/ -q 19 --barcode_type 'not-barcoded'
 
 **Quality filter (at Phred >= Q20) two non-multiplexed lanes of Illumina fastq data with different samples in each and write results to ./slout_not_multiplexed_q20.:**
 
 ::
 
-	split_libraries_fastq.py -i lane1_read1.fastq.gz,lane2_read1.fastq.gz --sample_id my.sample.1,my.sample.2 -o slout_not_multiplexed_q20/ -q 19 --barcode_type 'not-barcoded'
+	split_libraries_fastq.py -i lane1_read1.fastq.gz,lane2_read1.fastq.gz --sample_ids my.sample.1,my.sample.2 -o slout_not_multiplexed_q20/ -q 19 --barcode_type 'not-barcoded'
 
 

--- a/doc/scripts/split_libraries_fastq.rst
+++ b/doc/scripts/split_libraries_fastq.rst
@@ -7,7 +7,7 @@
 
 **Description:**
 
-The Illumina MiSeq platform commonly outputs sequence reads and barcode reads in seperate files. For example:
+The Illumina MiSeq platform commonly outputs sequence reads and barcode reads in separate files. For example:
 
 .. note::
 - "Example_S0_L001_R1_001.fastq.gz": 	R1 is read one, the forward read
@@ -17,7 +17,7 @@ When paired end reads are generated on an Illumina machine, they can be paired w
 
 .. note::
 - "fastqjoin.join.fastq":		the result of pairing the forward and reverse reads
-- "fastqjoin.join_barcodes.fastq": 	the barcodes for these newly paired reads
+- "fastqjoin.join_barcodes.fastq": 	the updated barcodes for these newly paired reads
 
 In both these cases, this script can be used to demultiplex the reads.fastq file using the barcodes.fastq file and `mapping file <http://qiime.org/documentation/file_formats.html#mapping-file-overview>`_.
 

--- a/doc/scripts/split_libraries_fastq.rst
+++ b/doc/scripts/split_libraries_fastq.rst
@@ -45,7 +45,7 @@ In both these cases, this script can be used to demultiplex the reads.fastq file
 		The barcode read fastq files (comma-separated if more than one) [default: None]
 	`-`-store_qual_scores
 		Store qual strings in .qual files [default: False]
-	`-`-sample_ids
+	`-`-sample_id
 		Comma-separated list of samples id to be applied to all sequences, must be one per input file path (used when data is not multiplexed) [default: None]
 	`-`-store_demultiplexed_fastq
 		Write demultiplexed fastq files [default: False]

--- a/doc/scripts/split_libraries_fastq.rst
+++ b/doc/scripts/split_libraries_fastq.rst
@@ -7,6 +7,19 @@
 
 **Description:**
 
+The Illumina MiSeq platform commonly outputs sequence reads and barcode reads in seperate files. For example:
+
+.. note::
+- "Example_S0_L001_R1_001.fastq.gz": 	R1 is read one, the forward read
+- "Example_S0_L001_I1_001.fastq.gz": 	I1 is the index, the barcode read
+
+When paired end reads are generated on an Illumina machine, they can be paired with `join_paired_ends.py <http://qiime.org/scripts/join_paired_ends.html>`_ and produce the following output:
+
+.. note::
+- "fastqjoin.join.fastq":		the result of pairing the forward and reverse reads
+- "fastqjoin.join_barcodes.fastq": 	the barcodes for these newly paired reads
+
+In both these cases, this script can be used to demultiplex the reads.fastq file using the barcodes.fastq file and `mapping file <http://qiime.org/documentation/file_formats.html#mapping-file-overview>`_.
 
 
 


### PR DESCRIPTION
Fixed spelling errors in the example commands as noted by @adamrp here: biocore/qiime#1940 
Also added description of when / why you would use this script.