### PR TITLE
Update of docs and test data

### DIFF
--- a/qiime_test_data/filter_fasta/map.txt
+++ b/qiime_test_data/filter_fasta/map.txt
@@ -1,3 +1,2 @@
-#SampleID   Description
-Sample1 Something good
-Sample3 Something boring
+S5
+S3

--- a/scripts/filter_fasta.py
+++ b/scripts/filter_fasta.py
@@ -68,7 +68,7 @@ script_info['optional_options'] = [
     make_option('-s', '--seq_id_fp', type='existing_filepath',
                 help="A list of sequence identifiers (or tab-delimited lines "
                      "with a seq identifier in the first field) which should "
-                     "retained."),
+                     "be retained."),
     make_option('-b', '--biom_fp', type='existing_filepath',
                 help='A biom file where otu identifiers should be retained.'),
     make_option('-a', '--subject_fasta_fp', type='existing_filepath',

--- a/scripts/filter_fasta.py
+++ b/scripts/filter_fasta.py
@@ -63,25 +63,31 @@ script_info['required_options'] = [
 ]
 script_info['optional_options'] = [
     make_option('-m', '--otu_map', type='existing_filepath',
-                help='an OTU map where sequences ids are those which should be retained'),
+                help="An OTU map where sequences ids are those which should be "
+                     "retained."),
     make_option('-s', '--seq_id_fp', type='existing_filepath',
-                help='A list of sequence identifiers (or tab-delimited lines with'
-                ' a seq identifier in the first field) which should be retained'),
+                help="A list of sequence identifiers (or tab-delimited lines "
+                     "with a seq identifier in the first field) which should "
+                     "retained."),
     make_option('-b', '--biom_fp', type='existing_filepath',
-                help='A biom file where otu identifiers should be retained'),
+                help='A biom file where otu identifiers should be retained.'),
     make_option('-a', '--subject_fasta_fp', type='existing_filepath',
                 help='A fasta file where the seq ids should be retained.'),
     make_option('-p', '--seq_id_prefix', type='string',
-                help='keep seqs where seq_id starts with this prefix'),
+                help='Keep seqs where seq_id starts with this prefix.'),
     make_option('--sample_id_fp', type='existing_filepath',
-                help='keep seqs where seq_id starts with a sample id listed in this file'),
-    make_option('-n', '--negate', help='discard passed seq ids rather than'
-                ' keep passed seq ids [default: %default]', default=False,
+                help="Keep seqs where seq_id starts with a sample id listed in "
+                     "this file. Must be newline delimited and may not contain "
+                     "a header."),
+    make_option('-n', '--negate', help='Discard passed seq ids rather than'
+                ' keep passed seq ids. [default: %default]', default=False,
                 action='store_true'),
     make_option('--mapping_fp', type='existing_filepath',
-                help='mapping file path (for use with --valid_states) [default: %default]'),
+                help="Mapping file path (for use with --valid_states). "
+                     "[default: %default]"),
     make_option('--valid_states', type='string',
-                help='description of sample ids to retain (for use with --mapping_fp) [default: %default]')
+                help="Description of sample ids to retain (for use with "
+                     "--mapping_fp). [default: %default]")
 ]
 script_info['version'] = __version__
 


### PR DESCRIPTION
filter_fasta.py contained ambiguous documentation for the --sample_id_fp option. Specifically, it was unclear what format the input file for the --sample_id_fp option should be in. This commit does three minor things:
1. Updates the help text for this option so its clear what format is expected.
2. Updates the qiime_test_data/filter_fasta/map.txt so that it conforms to the new documentation and actually exercises the functionality. The current master branch code filters out all sequences.
3. Makes the help options in the script documentation stylistically similar, i.e. same capitalization, punctuation, etc.