### PR TITLE
Update dataFiles.html

### DIFF
--- a/home_static/dataFiles.html
+++ b/home_static/dataFiles.html
@@ -38,10 +38,8 @@ pageTracker._trackPageview();
 		</li>
 		<hr>
 		<li>
-			<b><a href="http://www.arb-silva.de/">Silva</a> OTUs (16S/18S)</b><p>
-			<a href="ftp://ftp.microbio.me/pub/QIIME_nonstandard_referencedb/Silva_111.tgz">Silva release 111</a><p>
-			<a href="http://www.arb-silva.de/download/archive/qiime/">Silva releases 104, 108, 119</a><p>
-			<a href="ftp://ftp.microbio.me/pub/QIIME_nonstandard_referencedb/Silva_108_database_curated.tgz">Silva 108 database curated to reflect eukaryotic phylogeny</a> and <a href="ftp://ftp.microbio.me/pub/QIIME_nonstandard_referencedb/Silva_108_Qiime_format_notes.txt">associated notes</a>.
+			<b><a href="http://www.arb-silva.de/">SILVA</a> OTUs (16S/18S)</b><p>
+			<a href="http://www.arb-silva.de/download/archive/qiime/">QIIME-compatible SILVA releases 104, 108, 111, and 119, as well as the licensing information for commercial and non-commercial use.</a><p>
 		</li>
 		<hr>
 		<li>


### PR DESCRIPTION
Removing links to locally (ftp.microbio.me) hosted SILVA files per discussion with Dr. Quast from SILVA. The same files are now hosted on the SILVA site, and the text is updated to reflect this.