### PR TITLE
DOC: Fix random forest installation command

### DIFF
--- a/scripts/supervised_learning.py
+++ b/scripts/supervised_learning.py
@@ -64,7 +64,7 @@ error of the classified, and the pooled standard deviation (for cv5 and cv10 err
 
 This script requires that R be installed and in the search path. To install R \
 visit: http://www.r-project.org/. Once R is installed, run R and excecute the \
-command "install.packages("randomForest")", then type q() to exit."""
+command "install.packages('randomForest')", then type q() to exit."""
 
 script_info['script_usage'] = []
 


### PR DESCRIPTION
Using double quotes would yield an error, but single quotes let's you
install the package:

```R
> install.packages(“randomForest”)
Error: unexpected input in "install.packages(?"
> install.packages('randomForest')
Installing package into
‘/home/yova1074/R/x86_64-unknown-linux-gnu-library/3.1’
(as ‘lib’ is unspecified)
```