### PR TITLE
BUG: Add --read_arguments_from_file to sl_fastq.py

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 QIIME 1.9.1-dev (changes since 1.9.1 go here)
 =============================================
 
+Bug fixes
+---------
+
+* Add ``--read_arguments_from_file`` to ``split_libraries_fastq.py``, thus preventing ``multiple_split_libraries_fastq.py`` from failing with an `Argument list too long error` when the number of input files is large, see [#2069](https://github.com/biocore/qiime/issues/2069).
+
 QIIME 1.9.1
 ===========
 

--- a/qiime/parse.py
+++ b/qiime/parse.py
@@ -28,6 +28,7 @@ from cogent.parse.tree import DndParser
 from skbio.parse.sequences import parse_fastq
 from skbio.parse.sequences.fasta import FastaFinder
 from skbio.sequence import DNA
+from skbio.io.util import open_file
 from cogent.core.tree import PhyloNode
 
 
@@ -929,3 +930,24 @@ def parse_sample_id_map(sample_id_map_f):
                 result[samp_id] = mapped_id
                 new_samp_id_counts[mapped_id] += 1
     return result
+
+
+def parse_items(fp):
+    """Parse items from a file where each item is in a different line
+
+    Parameters
+    ----------
+    fp : str/bytes/unicode string or file-like
+        Filepath or file-like object to parse.
+
+    Returns
+    -------
+    list
+        List of the items parsed from the file
+    """
+    with open_file(fp, 'U') as f:
+        items = f.read().strip('\n').split('\n')
+
+    if items == ['']:
+        items = []
+    return items

--- a/qiime/workflow/preprocess.py
+++ b/qiime/workflow/preprocess.py
@@ -10,6 +10,7 @@ __email__ = "William.A.Walters@colorado.edu"
 
 
 from os.path import join, basename, splitext, exists
+from functools import partial
 
 
 def create_commands_jpe(pairs, base_output_dir, optional_params = "",
@@ -143,7 +144,7 @@ def create_commands_slf(all_files, demultiplexing_method, output_dir,
     sample_ids = []
 
     params_dict = {}
-    path_builder = lambda x: join(output_dir, x)
+    path_builder = partial(join, output_dir)
 
     # Using a set in this case to keep consistent order (needed for unit tests)
     all_fps = set(all_files)
@@ -199,7 +200,7 @@ def _make_file(elements, fp):
 
     Parameters
     ----------
-    elements : list
+    elements : list or tuple
         List of elements to be formatted one by line in the output file.
     fp : str
         Filepath where the file should be written to

--- a/scripts/multiple_split_libraries_fastq.py
+++ b/scripts/multiple_split_libraries_fastq.py
@@ -44,6 +44,17 @@ For example, sample1_L001_R1_001.fastq.gz, sample1_L001_I1_001.fastq.gz,
 sample1_L001_mapping_001.txt would be matched up if "R1" is the read indicator,
 "I1" is the barcode indicator, and "mapping" is the mapping file indicator.
 
+Depending on the inputed arguments, this script can create any of the following
+files in the output directory:
+
+    * seqs.txt: this file will contain a list (one element per line) of found
+      sequences filepaths.
+    * barcodes.txt: this file will contain a list (one element per line) of
+      found barcodes filepaths.
+    * map.txt: this file wil contain a list (one element per line) of mapping
+      file filepaths.
+    * sample_ids.txt: this file will contain a list (one element per line)
+      sample identifiers.
 """
 script_info['script_usage'] = []
 

--- a/scripts/multiple_split_libraries_fastq.py
+++ b/scripts/multiple_split_libraries_fastq.py
@@ -3,7 +3,7 @@ from __future__ import division
 
 __author__ = "William Walters"
 __copyright__ = "Copyright 2011, The QIIME Project"
-__credits__ = ["William Walters"]
+__credits__ = ["William Walters", "Yoshiki Vazquez Baeza"]
 __license__ = "GPL"
 __version__ = "1.9.1-dev"
 __maintainer__ = "William Walters"

--- a/scripts/split_libraries_fastq.py
+++ b/scripts/split_libraries_fastq.py
@@ -4,7 +4,8 @@ from __future__ import division
 
 __author__ = "Greg Caporaso"
 __copyright__ = "Copyright 2011, The QIIME project"
-__credits__ = ["Greg Caporaso", "Emily TerAvest"]
+__credits__ = ["Greg Caporaso", "Emily TerAvest", "Yoshiki Vazquez Baeza",
+               "Rob Knight"]
 __license__ = "GPL"
 __version__ = "1.9.1-dev"
 __maintainer__ = "Greg Caporaso"
@@ -137,7 +138,16 @@ script_info['optional_options'] = [
                 choices=['33', '64'], help="the ascii offset to use when "
                 "decoding phred scores (either 33 or 64). Warning: in most "
                 "cases you don't need to pass this value "
-                "[default: determined automatically]")
+                "[default: determined automatically]"),
+    make_option('--read_arguments_from_file', default=False,
+                action='store_true', help='If this flag is enabled, then the '
+                'inputs to "-i" or "--sequence_read_fps", "-b" or '
+                '"--barcode_read_fps", "-m" or "--mapping_fps" and '
+                '"--sample_ids" will each be interpreted as a single text file'
+                ', where the contents are one file-path or sample identifier '
+                'per line (depending on the flag). NOTE: In most cases regular'
+                ' users don\'t need to use this flag, as it is intended for '
+                'use in multiple_split_libraries_fastq.py [default: %default]')
     # NEED TO FIX THIS FUNCTIONALITY - CURRENTLY READING THE WRONG FIELD
     # make_option('--filter_bad_illumina_qual_digit',
     #    action='store_true',
@@ -151,6 +161,24 @@ script_info['version'] = __version__
 
 def main():
     option_parser, opts, args = parse_command_line_parameters(**script_info)
+    read_arguments_from_file = opts.read_arguments_from_file
+
+    # these arguments can optionally be read from a file, reasoning is to
+    # allow arguments that would span over hundreds of samples and would be
+    # prohibitive to execute as a command line call
+    if read_arguments_from_file:
+        read_f = lambda x: open(x, 'U').read().strip().split('\n')
+
+        # sample_ids is the only one of these arguments that's returned as a
+        # string, the rest of them are lists
+        if opts.sample_ids:
+            opts.sample_ids = ','.join(read_f(opts.sample_ids))
+        if opts.sequence_read_fps:
+            opts.sequence_read_fps = read_f(opts.sequence_read_fps[0])
+        if opts.barcode_read_fps:
+            opts.barcode_read_fps = read_f(opts.barcode_read_fps[0])
+        if opts.mapping_fps:
+            opts.mapping_fps = read_f(opts.mapping_fps[0])
 
     sequence_read_fps = opts.sequence_read_fps
     barcode_read_fps = opts.barcode_read_fps

--- a/scripts/split_libraries_fastq.py
+++ b/scripts/split_libraries_fastq.py
@@ -18,7 +18,7 @@ from skbio.sequence import DNA
 from skbio.format.sequences import format_fastq_record
 
 from qiime.util import parse_command_line_parameters, make_option, gzip_open
-from qiime.parse import parse_mapping_file
+from qiime.parse import parse_mapping_file, parse_items
 from qiime.split_libraries_fastq import (process_fastq_single_end_read_file,
                                          BARCODE_DECODER_LOOKUP, process_fastq_single_end_read_file_no_barcode)
 from qiime.split_libraries import check_map
@@ -167,18 +167,16 @@ def main():
     # allow arguments that would span over hundreds of samples and would be
     # prohibitive to execute as a command line call
     if read_arguments_from_file:
-        read_f = lambda x: open(x, 'U').read().strip().split('\n')
-
         # sample_ids is the only one of these arguments that's returned as a
         # string, the rest of them are lists
         if opts.sample_ids:
-            opts.sample_ids = ','.join(read_f(opts.sample_ids))
+            opts.sample_ids = ','.join(parse_items(opts.sample_ids))
         if opts.sequence_read_fps:
-            opts.sequence_read_fps = read_f(opts.sequence_read_fps[0])
+            opts.sequence_read_fps = parse_items(opts.sequence_read_fps[0])
         if opts.barcode_read_fps:
-            opts.barcode_read_fps = read_f(opts.barcode_read_fps[0])
+            opts.barcode_read_fps = parse_items(opts.barcode_read_fps[0])
         if opts.mapping_fps:
-            opts.mapping_fps = read_f(opts.mapping_fps[0])
+            opts.mapping_fps = parse_items(opts.mapping_fps[0])
 
     sequence_read_fps = opts.sequence_read_fps
     barcode_read_fps = opts.barcode_read_fps

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -33,7 +33,8 @@ from qiime.parse import (group_by_field, group_by_fields,
                          parse_taxa_summary_table, parse_prefs_file, parse_mapping_file_to_dict,
                          mapping_file_to_dict, MinimalQualParser, parse_denoiser_mapping,
                          parse_otu_map, parse_sample_id_map, parse_taxonomy_to_otu_metadata,
-                         is_casava_v180_or_later, MinimalSamParser)
+                         is_casava_v180_or_later, MinimalSamParser,
+                         parse_items)
 
 
 class TopLevelTests(TestCase):
@@ -1227,6 +1228,19 @@ otu3	s8_7	s2_5""".split('\n')
         sample_id_map = ['S1\ta', 'T1\ta', 'S2\ta']
         self.assertRaises(ValueError, parse_sample_id_map,
                           sample_id_map)
+
+    def test_parse_items(self):
+        x = StringIO('foo\nbar\nbaz\n')
+        self.assertEqual(['foo', 'bar', 'baz'], parse_items(x))
+
+        x = StringIO('\t\n\t\n\t\n')
+        self.assertEqual(['\t', '\t', '\t'], parse_items(x))
+
+        x = StringIO('111\n2222\n33333\n')
+        self.assertEqual(['111', '2222', '33333'], parse_items(x))
+
+        x = StringIO('')
+        self.assertEqual([], parse_items(x))
 
 
 illumina_read1 = """HWI-6X_9267:1:1:4:1699#ACCACCC/1:TACGGAGGGTGCGAGCGTTAATCGCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCGAAAAAAAAAAAAAAAAAAAAAAA:abbbbbbbbbb`_`bbbbbb`bb^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDaabbBBBBBBBBBBBBBBBBBBB

--- a/tests/test_workflow/test_preprocess.py
+++ b/tests/test_workflow/test_preprocess.py
@@ -326,7 +326,7 @@ class GenerateJoinPairedEndsCommands(TestCase):
                     "{output_dir}/sample_ids.txt --barcode_type "
                     "'not-barcoded' ").format(output_dir=output_dir)
 
-        self.assertEquals(actual_command, expected)
+        self.assertEqual(actual_command, expected)
 
     def test_create_commands_slf_mapping_barcodes(self):
         """ Properly creates commands for barcode/mapping files option """
@@ -346,7 +346,7 @@ class GenerateJoinPairedEndsCommands(TestCase):
                     "--barcode_read_fps {output_dir}/barcodes.txt "
                     "--mapping_fps {output_dir}/maps.txt ").format(
                     output_dir=output_dir)
-        self.assertEquals(actual_command, expected)
+        self.assertEqual(actual_command, expected)
 
     def test_create_commands_slf_added_options(self):
         """ Properly creates slf commands with added parameters """
@@ -370,7 +370,7 @@ class GenerateJoinPairedEndsCommands(TestCase):
                     "--read_arguments_from_file --sample_ids "
                     "{output_dir}/sample_ids.txt --barcode_type 'not-barcoded'"
                     "  | qsub -N BigErn -k oe").format(output_dir=output_dir)
-        self.assertEquals(actual_command, expected)
+        self.assertEqual(actual_command, expected)
 
     def test_creat_commands_slf_exception(self):
         all_files = ['sample1_r1.fastq', 'sample2_r1.fastq']
@@ -388,15 +388,14 @@ class GenerateJoinPairedEndsCommands(TestCase):
         fp = join(self.temp_dir, 'gzweep')
         observed = _make_file(a, fp)
         with open(fp) as f:
-            self.assertEquals('\n'.join(a), f.read())
-        self.assertEquals(observed, fp)
+            self.assertEqual('\n'.join(a), f.read())
+        self.assertEqual(observed, fp)
 
         fp = join(self.temp_dir, 'gzweep')
         observed = _make_file([], fp)
         with open(observed) as f:
-            self.assertEquals('', f.read())
-        self.assertEquals(observed, fp)
-
+            self.assertEqual('', f.read())
+        self.assertEqual(observed, fp)
 
 
 if __name__ == '__main__':

--- a/tests/test_workflow/test_preprocess.py
+++ b/tests/test_workflow/test_preprocess.py
@@ -372,6 +372,16 @@ class GenerateJoinPairedEndsCommands(TestCase):
                     "  | qsub -N BigErn -k oe").format(output_dir=output_dir)
         self.assertEquals(actual_command, expected)
 
+    def test_creat_commands_slf_exception(self):
+        all_files = ['sample1_r1.fastq', 'sample2_r1.fastq']
+        demultiplexing_method = 'sampleid_by_file'
+        output_dir = 'foo-boo-loo-bloop'
+
+        with self.assertRaises(IOError):
+            actual_command = create_commands_slf(all_files,
+                                                 demultiplexing_method,
+                                                 output_dir)[0][0][1]
+
     def test_make_file(self):
         a = ['/foo/bar/baz.fastq.gz', '/pleep/ploop/bloom.fastq.gz',
              '/foo/bar/beezzz.fastq.gz', '/a/b/c/d/e/f/g/h.fastq.gz']

--- a/tests/test_workflow/test_preprocess.py
+++ b/tests/test_workflow/test_preprocess.py
@@ -10,6 +10,9 @@ __maintainer__ = "William Walters"
 __email__ = "William.A.Walters@colorado.edu"
 
 from unittest import TestCase, main
+from tempfile import mkdtemp
+from shutil import rmtree
+from os.path import join
 
 from qiime.workflow.preprocess import (get_pairs, get_matching_files,
     create_commands_jpe, create_commands_eb, create_commands_slf, _make_file)
@@ -17,13 +20,10 @@ from qiime.workflow.preprocess import (get_pairs, get_matching_files,
 class GenerateJoinPairedEndsCommands(TestCase):
 
     def setUp(self):
-        # create the temporary input files that will be used
-        # Shouldn't need any for this script, as all file IO is in scripts/
-        pass
+        self.temp_dir = mkdtemp()
 
     def tearDown(self):
-        # Should not need any file/folder removal
-        pass
+        rmtree(self.temp_dir)
 
     def test_get_pairs(self):
         """ Properly returns pairs of matching fastq forward/reverse reads """
@@ -315,21 +315,18 @@ class GenerateJoinPairedEndsCommands(TestCase):
 
         all_files = ['sample1_r1.fastq', 'sample2_r1.fastq']
         demultiplexing_method = 'sampleid_by_file'
-        output_dir = "sl_out"
+        # the output directory has to exist
+        output_dir = self.temp_dir
 
         actual_command = create_commands_slf(all_files, demultiplexing_method,
             output_dir)[0][0][1]
 
-        expected_command = "split_libraries_fastq.py  -i sample1_r1.fastq,sample2_r1.fastq --sample_ids sample1,sample2 -o sl_out  --barcode_type 'not-barcoded'"
+        expected = ("split_libraries_fastq.py  -i {output_dir}/seqs.txt -o "
+                    "{output_dir} --read_arguments_from_file --sample_ids "
+                    "{output_dir}/sample_ids.txt --barcode_type "
+                    "'not-barcoded' ").format(output_dir=output_dir)
 
-        #self.assertEqual(actual_command, expected_command)
-
-        self.assertTrue(actual_command.startswith('split_libraries_fastq.py  '
-                                                  '-i '))
-        self.assertTrue(' -o sl_out --read_arguments_from_file --sample_ids '
-                        in actual_command)
-        self.assertTrue(actual_command.endswith(" --barcode_type 'not-barcoded"
-                                                "' "))
+        self.assertEquals(actual_command, expected)
 
     def test_create_commands_slf_mapping_barcodes(self):
         """ Properly creates commands for barcode/mapping files option """
@@ -338,24 +335,26 @@ class GenerateJoinPairedEndsCommands(TestCase):
             'sample1_bc.fastq'), 'sample2_r1.fastq':('sample2_mapping.txt',
             'sample2_bc.fastq')}
         demultiplexing_method = 'mapping_barcode_files'
-        output_dir = "sl_out"
+        # the output directory has to exist
+        output_dir = self.temp_dir
 
         actual_command = create_commands_slf(all_files, demultiplexing_method,
             output_dir)[0][0][1]
 
-        self.assertTrue(actual_command.startswith('split_libraries_fastq.py  -'
-                                                  'i '))
-        self.assertTrue(' --barcode_read_fps ' in actual_command)
-        self.assertTrue(' --mapping_fps ' in actual_command)
-        self.assertTrue(' -o sl_out --read_arguments_from_file' in
-                        actual_command)
+        expected = ("split_libraries_fastq.py  -i {output_dir}/seqs.txt -o "
+                    "{output_dir} --read_arguments_from_file "
+                    "--barcode_read_fps {output_dir}/barcodes.txt "
+                    "--mapping_fps {output_dir}/maps.txt ").format(
+                    output_dir=output_dir)
+        self.assertEquals(actual_command, expected)
 
     def test_create_commands_slf_added_options(self):
         """ Properly creates slf commands with added parameters """
 
         all_files = ['sample1/sample_r1.fastq', 'sample2/sample_r1.fastq']
         demultiplexing_method = 'sampleid_by_file'
-        output_dir = "sl_out"
+        # the output directory has to exist
+        output_dir = self.temp_dir
         params = "--max_bad_run_length 15"
         leading_text = "echo"
         trailing_text = " | qsub -N BigErn -k oe"
@@ -366,34 +365,27 @@ class GenerateJoinPairedEndsCommands(TestCase):
             output_dir, params, leading_text, trailing_text,
             include_input_dir_path, remove_filepath_in_name)[0][0][1]
 
-        self.assertTrue(actual_command.startswith("echo split_libraries_fastq."
-                                                  "py --max_bad_run_length 15 "
-                                                  "-i "))
-        self.assertTrue(' -o sl_out --read_arguments_from_file' in
-                        actual_command)
-        self.assertTrue(" --sample_ids " in actual_command)
-        self.assertTrue(actual_command.endswith(" --barcode_type 'not-barcoded"
-                                                "'  | qsub -N BigErn -k oe"))
-
-
+        expected = ("echo split_libraries_fastq.py --max_bad_run_length 15 -i "
+                    "{output_dir}/seqs.txt -o {output_dir} "
+                    "--read_arguments_from_file --sample_ids "
+                    "{output_dir}/sample_ids.txt --barcode_type 'not-barcoded'"
+                    "  | qsub -N BigErn -k oe").format(output_dir=output_dir)
+        self.assertEquals(actual_command, expected)
 
     def test_make_file(self):
         a = ['/foo/bar/baz.fastq.gz', '/pleep/ploop/bloom.fastq.gz',
              '/foo/bar/beezzz.fastq.gz', '/a/b/c/d/e/f/g/h.fastq.gz']
-        observed = _make_file(a, 'gzweep')
-        with open(observed) as f:
+        fp = join(self.temp_dir, 'gzweep')
+        observed = _make_file(a, fp)
+        with open(fp) as f:
             self.assertEquals('\n'.join(a), f.read())
+        self.assertEquals(observed, fp)
 
-        # no prefix
-        a = ['/foo/bar/baz.fastq.gz', '/pleep/ploop/bloom.fastq.gz',
-             '/foo/bar/beezzz.fastq.gz', '/a/b/c/d/e/f/g/h.fastq.gz']
-        observed = _make_file(a)
-        with open(observed) as f:
-            self.assertEquals('\n'.join(a), f.read())
-
-        observed = _make_file([])
+        fp = join(self.temp_dir, 'gzweep')
+        observed = _make_file([], fp)
         with open(observed) as f:
             self.assertEquals('', f.read())
+        self.assertEquals(observed, fp)
 
 
 


### PR DESCRIPTION
With this new argument split_libraries_fastq.py can now take a file that
list the input files for the `-b`, `-i`, `--sample_ids` and
`--mapping_files` arguments. Thus allowing an indefinite amount of files
as inputs, as opposed to the previous approach where we would be limited
by the maximum number of characters that can fit into a single command
line execution.

Fixes #2069

cc @walterst @gregcaporaso