### PR TITLE
modified parse.parse_otu_map and rarefaction.RarefactionMaker

### DIFF
--- a/qiime/parse.py
+++ b/qiime/parse.py
@@ -878,7 +878,10 @@ def parse_otu_map(otu_map_f, otu_ids_to_exclude=None, delim='_'):
         if otu_id in otu_ids_to_exclude:
             continue
         for seq_id in fields[1:]:
-            sample_id = re.search('(\S+)%s\d+$'%delim,seq_id).group(1)
+            try:
+                sample_id = re.search('(\S+)%s\d+$'%delim,seq_id).group(1)
+            except AttributeError:
+                sample_id = seq_id
             try:
                 sample_index = sample_id_idx[sample_id]
             except KeyError:

--- a/qiime/parse.py
+++ b/qiime/parse.py
@@ -878,7 +878,7 @@ def parse_otu_map(otu_map_f, otu_ids_to_exclude=None, delim='_'):
         if otu_id in otu_ids_to_exclude:
             continue
         for seq_id in fields[1:]:
-            sample_id = seq_id.split(delim)[0]
+            sample_id = re.search('(\S+)%s\d+$'%delim,seq_id).group(1)
             try:
                 sample_index = sample_id_idx[sample_id]
             except KeyError:

--- a/qiime/rarefaction.py
+++ b/qiime/rarefaction.py
@@ -77,13 +77,13 @@ class SingleRarefactionMaker(FunctionWithParams):
 
 class RarefactionMaker(FunctionWithParams):
 
-    def __init__(self, otu_path, min, max, step, num_reps):
+    def __init__(self, otu_path, min, max, step, num_reps, ranges=None):
         """ init a rarefactionmaker
 
         otu_path is path to .biom otu table
         we just ignore any rarefaction levels beyond any sample in the data
         """
-        self.rare_depths = range(min, max + 1, step)
+        self.rare_depths = ranges or range(min, max + 1, step)
         self.num_reps = num_reps
         self.otu_table = self.getBiomData(otu_path)
         self.max_num_taxa = -1


### PR DESCRIPTION
1. I have changed the function: `parse_otu_map` in *parse.py*, use regular expression(`re.search`) rather than `str.split`;This will allow seq_id like: 'Sample_one' when delim is '_'.
2. modifed the `RarefactionMaker.__init__` in *rarefaction.py*, add an argument: `ranges`; This will help great when use **gradual ranges**, for example:`ranges=range(10,1000,10)+range(1000,4000,100)+range(4000,20000,1000)`, because the rarefaction is much more sensitive at the begining.