### PR TITLE
Mnt remove pylab imports in favor of `pyplot`

### DIFF
--- a/qiime/make_2d_plots.py
+++ b/qiime/make_2d_plots.py
@@ -249,7 +249,8 @@ def make_interactive_scatter(plot_label, dir_path, data_file_link,
     mtitle = props.get("title", "Groups")
     x_label = props.get("xlabel", "X")
     y_label = props.get("ylabel", "Y")
-    fig, ax = plt.subplots()
+    ax = plt.gca()
+    fig = ax.figure
     ax.set_title('%s' % mtitle, fontsize='10', color=label_color)
     ax.set_xlabel(x_label, fontsize='8', color=label_color)
     ax.set_ylabel(y_label, fontsize='8', color=label_color)

--- a/qiime/make_rarefaction_plots.py
+++ b/qiime/make_rarefaction_plots.py
@@ -15,7 +15,7 @@ from matplotlib import use
 use('Agg', warn=False)
 from sys import exit
 from qiime.parse import parse_rarefaction_data
-from matplotlib.pylab import savefig, clf, gca, gcf, errorbar
+from matplotlib.pyplot import savefig, clf, gca, gcf, errorbar
 import matplotlib.pyplot as plt
 import os.path
 from os.path import splitext, split

--- a/qiime/plot_taxa_summary.py
+++ b/qiime/plot_taxa_summary.py
@@ -23,7 +23,8 @@ matplotlib.use('Agg', warn=False)
 from matplotlib.font_manager import FontProperties
 from matplotlib.pyplot import (rc, axis, title, axes, pie, clf,
                                savefig, figure, close)
-
+import matplotlib.patches as mpatches
+from itertools import cycle
 import numpy as numpy
 from random import choice, randrange
 import os
@@ -160,12 +161,8 @@ def make_legend(data_ids, colors, plot_width, plot_height, label_color,
         if len(i) > max_id_len:
             max_id_len = len(i)
 
-    # define the figure and a separate figure for the legend
-    fig = figure(randrange(10000), figsize=(1, 1))
-
     # numbers multiplied by were tweaked by hand
     figlegend = figure(figsize=(max_id_len * 0.15, num_ids * 0.22))
-    ax = fig.add_subplot(111)
 
     # set some of the legend parameters
     fsize = 6
@@ -175,16 +172,15 @@ def make_legend(data_ids, colors, plot_width, plot_height, label_color,
     rc('axes', linewidth=0, edgecolor=label_color)
     rc('text', usetex=False)
 
-    y = numpy.arange(len(data_ids))
-    barg = ax.bar(y, y, color=colors, label=data_ids)
-    l = figlegend.legend(barg, tuple(data_ids), loc='center left',
+    proxies = [mpatches.Patch(color=c, label=lab)
+               for c, lab in zip(cycle(colors), data_ids)]
+    l = figlegend.legend(handles=proxies, labels=data_ids,
+                         loc='center left',
                          shadow=False, fancybox=False)
     l.legendPatch.set_alpha(0)
 
     figlegend.savefig(out_fpath, dpi=dpi, facecolor=background_color)
-    close(fig)
     close(figlegend)
-    clf()
 
     return fname
 

--- a/qiime/plot_taxa_summary.py
+++ b/qiime/plot_taxa_summary.py
@@ -18,23 +18,17 @@ Python 2.7
 """
 
 import matplotlib
-import re
+
 matplotlib.use('Agg', warn=False)
 from matplotlib.font_manager import FontProperties
-from pylab import rc, axis, title, axes, pie, figlegend, clf, savefig, figure\
-    , close
-from string import strip
-from numpy import array
+from matplotlib.pyplot import (rc, axis, title, axes, pie, clf,
+                               savefig, figure, close)
+
 import numpy as numpy
-from optparse import OptionParser
-from collections import defaultdict
-from time import strftime
 from random import choice, randrange
 import os
 import shutil
-from qiime.util import get_qiime_project_dir
-from qiime.colors import natsort, data_color_order, data_colors, \
-    get_group_colors, iter_color_groups
+from qiime.colors import (data_colors, get_group_colors)
 from qiime.parse import group_by_field
 
 ALPHABET = "ABCDEFGHIJKLMNOPQRSTUZWXYZ"

--- a/qiime/quality_scores_plot.py
+++ b/qiime/quality_scores_plot.py
@@ -14,9 +14,10 @@ from matplotlib import use
 use('Agg', warn=False)
 from skbio.parse.sequences import parse_fasta
 from numpy import arange, std, average
-from pylab import plot, savefig, xlabel, ylabel, text, \
-    hist, figure, legend, title, show, xlim, ylim, xticks, yticks,\
-    scatter, subplot
+from matplotlib.pyplot import (plot, savefig, xlabel, ylabel, text,
+                               hist, figure, legend, title, show,
+                               xlim, ylim, xticks, yticks, scatter,
+                               subplot)
 from matplotlib.font_manager import fontManager, FontProperties
 from qiime.util import gzip_open
 from qiime.parse import parse_qual_score

--- a/scripts/compute_core_microbiome.py
+++ b/scripts/compute_core_microbiome.py
@@ -14,7 +14,7 @@ from os.path import join
 
 from matplotlib import use
 use('Agg', warn=False)
-from pylab import xlim, ylim, xlabel, ylabel, plot, savefig
+from matplotlib.pyplot import xlim, ylim, xlabel, ylabel, plot, savefig
 import numpy as np
 from skbio.util import create_dir
 from biom import load_table

--- a/scripts/plot_semivariogram.py
+++ b/scripts/plot_semivariogram.py
@@ -20,8 +20,8 @@ from qiime.filter import (filter_samples_from_distance_matrix,
                           sample_ids_from_metadata_description)
 from matplotlib import use
 use('Agg', warn=False)
-from pylab import (plot, xlabel, ylabel, title, savefig, ylim, xlim, legend,
-                   show, figure)
+from matplotlib.pyplot import (plot, xlabel, ylabel, title, savefig, ylim,
+                               xlim, legend, show, figure)
 from numpy import asarray
 import os
 from os.path import splitext

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ def build_swarm():
 
 # don't build any of the non-Python dependencies if the following modes are
 # invoked
-if all([e not in sys.argv for e in 'egg_info', 'sdist', 'register']):
+if all([e not in sys.argv for e in ('egg_info', 'sdist', 'register')]):
     catch_install_errors(build_denoiser, 'denoiser')
     catch_install_errors(download_UCLUST, 'UCLUST')
     catch_install_errors(build_FastTree, 'FastTree')


### PR DESCRIPTION
Convert use of `pylab` to `matplotlib.pyplot`.  pylab is intended for interactive use, not in scripts/libraries. We are also trying to discourage the use of the `pylab` namespace (but will never actually deprecate it).

There is also someone squating on pylab on pypi (https://pypi.python.org/pypi/pylab) which can cause confusion for your users which shows up on the mpl mailing lists.