### PR TITLE
Update join_paired_ends.py

### DIFF
--- a/scripts/join_paired_ends.py
+++ b/scripts/join_paired_ends.py
@@ -87,12 +87,12 @@ script_info['optional_options'] = [
     make_option('-j', '--min_overlap', type='int',
                 help='Applies to both fastq-join and SeqPrep methods.' +
                       ' Minimum allowed overlap in base-pairs required to join pairs.' +
-                      ' If not set, progam defaults will be used.'
+                      ' If not set, progam defaults will be used. For example, for fastq-join (6 bp) will be used.'
                       ' Must be an integer. [default: %default]', default=None),
     make_option('-p', '--perc_max_diff', type='int',
                 help='Only applies to fastq-join method, otherwise ignored. ' +
                      'Maximum allowed % differences within region of overlap.' +
-                      ' If not set, progam defaults will be used.' +
+                      ' If not set, progam defaults will be used. For example, for fastq-join (8%) will be used.' +
                       ' Must be an integer between 1-100 [default: %default]',
                 default=None),
     make_option('-y', '--max_ascii_score',


### PR DESCRIPTION
I added some additional information clarifying the fact that not using a -m or a -j will still result in values being used. For example the defaults of fast-q-join are 6bp and 8% maximum mismatch.