### PR TITLE
MAINT: Site down due to deprecated Google API

### DIFF
--- a/home_static/qiime.js
+++ b/home_static/qiime.js
@@ -84,11 +84,12 @@ function loadCitations(selected_item)
 
 function loadHeaderFooter(selected_page)
 {
-    if(selected_page == 'main')
-        load();
     document.getElementById('header').innerHTML = getFile("/home_static/header.html");
     document.getElementById('leftcol').innerHTML = getFile("/home_static/leftcol.html");
     document.getElementById('footer').innerHTML = getFile("/home_static/footer.html");
+
+    if(selected_page == 'main')
+        load();
 }
 
 


### PR DESCRIPTION
A Google API that has been deleted was being called before the page could be generated dynamically and crashing the JavaScript. This changes the order so it'll crash afterwards.

|Before |After |
|-|-|
|![image](https://cloud.githubusercontent.com/assets/2638727/23006958/4a80b360-f3c2-11e6-814d-2608964f750d.png)| ![image](https://cloud.githubusercontent.com/assets/2638727/23007001/824ca808-f3c2-11e6-960d-7191c03a094a.png)|

