### PR TITLE
avoid np.diff on binary array

### DIFF
--- a/qiime/split_libraries_fastq.py
+++ b/qiime/split_libraries_fastq.py
@@ -65,7 +65,7 @@ def _contiguous_regions(condition):
     """
 
     # Find the indicies of changes in "condition"
-    d = np.diff(condition)
+    d = np.diff(condition.astype(np.int8))
     idx, = d.nonzero()
 
     # We need to start things after the change in "condition". Therefore,


### PR DESCRIPTION
fixes deprecated behavior:
https://groups.google.com/forum/#!topic/qiime-forum/ccyPJWRFseA
https://stackoverflow.com/questions/24216210/boolean-subtract-deprecationwarning

not a priority—feel free to ignore.