### PR TITLE
quickfix URL for blast in non-conda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@ QIIME: Quantitative Insights Into Microbial Ecology
 
 [![Build Status](http://ci.qiime.org/job/QIIME/badge/icon)](http://ci.qiime.org/job/QIIME/)
 
-For information on QIIME, see the [QIIME website](http://www.qiime.org). To get help with using QIIME, visit http://help.qiime.org.
+**[QIIME 2](https://qiime2.org) will succeed QIIME 1 on January 1, 2018. QIIME 1 will no longer be supported at that time**, as development and support effort for QIIME will be focused entirely on QIIME 2.
 
-**QIIME 1 is now considered to be in maintenance mode as we shift our development efforts to [QIIME 2](http://github.com/qiime2). We don't expect to release any new versions of QIIME 1, except for critical bug fixes if necessary. If you're interested in contributing to QIIME, please consider [contributing to QIIME 2](https://github.com/qiime2/qiime2/blob/master/CONTRIBUTING.md).**
+We recommend that existing QIIME users begin transitioning from QIIME 1 to QIIME 2 now. If you're new to QIIME, you should start by learning QIIME 2, not QIIME 1.
+
+QIIME 1 is now considered to be in maintenance mode as we shift our development efforts to [QIIME 2](http://github.com/qiime2). We don't expect to release any new versions of QIIME 1, except for critical bug fixes if necessary. If you're interested in contributing to QIIME, please consider [contributing to QIIME 2](https://github.com/qiime2/qiime2/blob/master/CONTRIBUTING.md).
+
+For information on QIIME, see the [QIIME website](http://www.qiime.org). To get help with using QIIME, visit http://help.qiime.org.
 
 For related software projects and data, see [biocore](http://biocore.github.io).

--- a/doc/install/alternative.rst
+++ b/doc/install/alternative.rst
@@ -131,8 +131,8 @@ Alignment, tree-building, taxonomy assignment, OTU picking, and other data gener
 
 * jre1.6.0_05 (`src_jre <http://java.sun.com/javase/downloads/index.jsp>`_) (license: GPL2)
 * rdp_classifier-2.2 (`src_rdp <http://sourceforge.net/projects/rdp-classifier/files/rdp-classifier/rdp_classifier_2.2.zip/download>`_) See :ref:`RDP install notes <rdp-install>`. (license: GPL)
-* blast-2.2.22 (legacy BLAST, *not* BLAST+) (binary for `OS X <ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/blast-2.2.22-universal-macosx.tar.gz>`_, `linux 32-bit
-<ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/blast-2.2.22-ia32-linux.tar.gz>`_, `other versions<ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/>`_) (license: GNU)
+* blast-2.2.22 (legacy BLAST from NCBI, *NOT* BLAST+) (binary for `OS X <ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/blast-2.2.22-universal-macosx.tar.gz>`_ or `linux 32-bit
+<ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/blast-2.2.22-ia32-linux.tar.gz>`_) (license: GNU)
 * cd-hit 3.1.1 (`src_cdhit <http://www.bioinformatics.org/download/cd-hit/cd-hit-2007-0131.tar.gz>`_) (license: Free access)
 * ChimeraSlayer (via microbiomeutil_2010-04-29) (`src_chimeraslayer <http://sourceforge.net/projects/microbiomeutil/files/>`_) See :ref:`ChimeraSlayer install notes <chimeraslayer-install>`.
 * mothur 1.25.0 (`src_mothur <http://www.mothur.org/w/images/6/6d/Mothur.1.25.0.zip>`_) (license: GPL)

--- a/doc/install/alternative.rst
+++ b/doc/install/alternative.rst
@@ -131,7 +131,8 @@ Alignment, tree-building, taxonomy assignment, OTU picking, and other data gener
 
 * jre1.6.0_05 (`src_jre <http://java.sun.com/javase/downloads/index.jsp>`_) (license: GPL2)
 * rdp_classifier-2.2 (`src_rdp <http://sourceforge.net/projects/rdp-classifier/files/rdp-classifier/rdp_classifier_2.2.zip/download>`_) See :ref:`RDP install notes <rdp-install>`. (license: GPL)
-* blast-2.2.22 (legacy BLAST from NCBI, *NOT* BLAST+) (`OS X <ftp://ftp.ncbi.nlm.nih.gov/blast/executables/release/2.2.22/blast-2.2.22-universal-macosx.tar.gz>`_ or `linux 32-bit <ftp://ftp.ncbi.nlm.nih.gov/blast/executables/release/2.2.22/blast-2.2.22-ia32-linux.tar.gz>`_) (license: GNU)
+* blast-2.2.22 (legacy BLAST, *not* BLAST+) (binary for `OS X <ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/blast-2.2.22-universal-macosx.tar.gz>`_, `linux 32-bit
+<ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/blast-2.2.22-ia32-linux.tar.gz>`_, `other versions<ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.22/>`_) (license: GNU)
 * cd-hit 3.1.1 (`src_cdhit <http://www.bioinformatics.org/download/cd-hit/cd-hit-2007-0131.tar.gz>`_) (license: Free access)
 * ChimeraSlayer (via microbiomeutil_2010-04-29) (`src_chimeraslayer <http://sourceforge.net/projects/microbiomeutil/files/>`_) See :ref:`ChimeraSlayer install notes <chimeraslayer-install>`.
 * mothur 1.25.0 (`src_mothur <http://www.mothur.org/w/images/6/6d/Mothur.1.25.0.zip>`_) (license: GPL)


### PR DESCRIPTION
Folks on the forms have not been able to download legacy-blast because the download location has changed. See these threads:
- https://groups.google.com/forum/#!topic/qiime-forum/oneq4GTxXcQ 
- https://groups.google.com/forum/#!topic/qiime-forum/MkldTFcJbCU

Let me know if you have any suggestions.